### PR TITLE
86 crypto enrich data ingestion with additional data for ml

### DIFF
--- a/notebooks/01_eda/results/eda_insight_btc_1hr.md
+++ b/notebooks/01_eda/results/eda_insight_btc_1hr.md
@@ -21,3 +21,48 @@
 1. **Build our own target:** Instead of trusting the pipeline's naming, we will engineer a brand new `target_1h` column so we know exactly what the model is predicting (using `shift(-1)`).
 2. **Chronological Splitting:** We cannot use a random Train/Test split. We must split the data strictly by time to prevent Lookahead Bias.
 3. **Scaling:** We will scale the features (like RSI and Volume) so they are on the same numerical level, but we make sure to only fit the scaler on the Training data!
+
+---
+
+**Date:** 2026-05-16
+
+### What We Found in the New Data (After Pipeline Fixes)
+
+- **Pipeline is Fixed:** After fixing the Bybit API keys and the `dropna()` bug, the gold layer now has **489,821 crypto rows** (11 symbols × 4 intervals) and **44,520 stock rows** (6 stocks × 4 intervals). The old problem where all rows got dropped is gone — only ~6,000 rows are lost for indicator warm-up.
+
+- **Three New Columns:** The pipeline now includes `open_interest`, `funding_rate`, and `turnover` for crypto. These come from Bybit's API, not from our own calculations. Stocks don't have these columns (they only have OHLCV + indicators).
+
+### Open Interest — The Good One
+
+- **Coverage is solid for 1h and 1d:** OI has 95-100% coverage on 1-hour and 1-day intervals across all 11 symbols. For weekly and monthly, it's 0% — Bybit doesn't map OI to those intervals, so we drop it there.
+- **BTC 1h:** OI starts from July 2020 (near the beginning of our data). After the warm-up period, only 4% of rows are missing — totally usable.
+- **Raw OI is NOT correlated with returns:** Spearman correlation is -0.012 (basically zero). This makes sense — the absolute level of open interest doesn't tell you if price goes up or down.
+- **But OI CHANGES matter:** When we looked at the top 50 biggest OI spikes, the average next-hour return was **0.15%** (24× the baseline of 0.006%). Big OI drops also had above-average returns at 0.09%. This means `oi_change` (pct_change of OI) is a real feature we should engineer for ML.
+
+### Funding Rate — The Broken One
+
+- **97% of funding rate data is missing.** For BTC 1h, the first valid funding rate date is March 11, 2026 — only 2 months out of 6 years of price data. The `merge_asof` in the pipeline is too strict and most of the historical funding rate data never gets matched to the kline timestamps.
+- **Even when present, correlation is zero:** Spearman = 0.017. Funding rate changes every 8 hours on Bybit, so merging it onto 1h candles means most rows get the same value via `ffill()`. It adds almost no signal at hourly granularity.
+- **Verdict:** We should either fix the merge logic to capture more history, or drop funding rate entirely for now. It's not helping ML in its current state.
+
+### Turnover — The Reliable One
+
+- **100% coverage across all intervals.** Turnover comes directly from Bybit's kline API (it's the quote currency volume, e.g., USDT traded). Every candle has it.
+- **Correlation with returns is weak (0.014),** but like OI, the raw value isn't what matters — `turnover_change` or `turnover_ratio` (turnover / volume) might be useful features.
+
+### What This Means for ML
+
+| Interval | OI usable? | Funding Rate usable? | Turnover usable? |
+|----------|-----------|---------------------|-----------------|
+| 1h |  Yes (use `oi_change`) |  No (97% NaN) |  Yes |
+| 1d |  Yes (use `oi_change`) |  No (96% NaN) |  Yes |
+| W |  No (0%) |  No (only 9 rows) |  Yes |
+| M |  No (0%) |  No |  Yes |
+
+### Our Plan for Feature Engineering
+
+1. **Engineer `oi_change`:** Instead of using raw `open_interest`, we will create `oi_change_1p` (1-period pct change) and maybe `oi_change_5p` / `oi_change_20p` for multi-period OI momentum.
+2. **Engineer turnover features:** Create `turnover_ratio` (turnover / volume) and `turnover_change` to capture when dollar volume spikes relative to coin volume.
+3. **Drop funding rate for now:** Until we fix the merge logic, funding rate is dead weight. We skip it in feature engineering.
+4. **Focus on 1h and 1d intervals:** Weekly and monthly don't have OI, so for those we fall back to OHLCV + technical indicators only.
+5. **Same chronological split and scaling rules apply:** No random splits, fit scaler only on training data, use `shift(-1)` for forward-looking targets.

--- a/scripts/test_bybit_api.py
+++ b/scripts/test_bybit_api.py
@@ -1,0 +1,88 @@
+"""Quick test to inspect raw Bybit API response for Open Interest and Funding Rate"""
+import os
+import json
+from dotenv import load_dotenv
+from pybit.unified_trading import HTTP
+
+load_dotenv()
+api_key = os.getenv("BYBIT_API_KEY")
+api_secret = os.getenv("BYBIT_API_SECRET")
+
+session = HTTP(testnet=False, api_key=api_key, api_secret=api_secret)
+
+symbol = "BTCUSDT"
+
+print("=" * 60)
+print("1. OPEN INTEREST (1h)")
+print("=" * 60)
+oi_response = session.get_open_interest(
+    category="linear",
+    symbol=symbol,
+    intervalTime="1h",
+    limit=5
+)
+print(f"Full response keys: {list(oi_response.keys())}")
+print(f"retCode: {oi_response.get('retCode')}")
+print(f"retMsg: {oi_response.get('retMsg')}")
+raw_list = oi_response.get('result', {}).get('list', [])
+print(f"List length: {len(raw_list)}")
+if raw_list:
+    print(f"Type of first item: {type(raw_list[0])}")
+    print(f"First item: {json.dumps(raw_list[0], indent=2)}")
+    if isinstance(raw_list[0], dict):
+        print(f"Keys: {list(raw_list[0].keys())}")
+        print(f"Has 'timestamp': {'timestamp' in raw_list[0]}")
+        print(f"Has 'openInterest': {'openInterest' in raw_list[0]}")
+        print(f"Has 'openInterestValue': {'openInterestValue' in raw_list[0]}")
+    elif isinstance(raw_list[0], list):
+        print(f"Length: {len(raw_list[0])}")
+else:
+    print(f"Full result: {json.dumps(oi_response.get('result'), indent=2)}")
+
+print()
+print("=" * 60)
+print("2. FUNDING RATE HISTORY")
+print("=" * 60)
+fr_response = session.get_funding_rate_history(
+    category="linear",
+    symbol=symbol,
+    limit=5
+)
+print(f"Full response keys: {list(fr_response.keys())}")
+print(f"retCode: {fr_response.get('retCode')}")
+print(f"retMsg: {fr_response.get('retMsg')}")
+raw_list = fr_response.get('result', {}).get('list', [])
+print(f"List length: {len(raw_list)}")
+if raw_list:
+    print(f"Type of first item: {type(raw_list[0])}")
+    print(f"First item: {json.dumps(raw_list[0], indent=2)}")
+    if isinstance(raw_list[0], dict):
+        print(f"Keys: {list(raw_list[0].keys())}")
+        print(f"Has 'timestamp': {'timestamp' in raw_list[0]}")
+        print(f"Has 'fundingRate': {'fundingRate' in raw_list[0]}")
+        print(f"Has 'fundingRateTimestamp': {'fundingRateTimestamp' in raw_list[0]}")
+    elif isinstance(raw_list[0], list):
+        print(f"Length: {len(raw_list[0])}")
+
+print()
+print("=" * 60)
+print("3. KLINE RESPONSE (to verify list item format)")
+print("=" * 60)
+kline_response = session.get_kline(
+    category="linear",
+    symbol=symbol,
+    interval="60",
+    limit=3
+)
+raw_list = kline_response.get('result', {}).get('list', [])
+if raw_list:
+    print(f"Type of first kline item: {type(raw_list[0])}")
+    print(f"First kline item: {json.dumps(raw_list[0], indent=2)}")
+    if isinstance(raw_list[0], list):
+        print(f"Kline is an ARRAY (positional access works)")
+        print(f"Length: {len(raw_list[0])}")
+    elif isinstance(raw_list[0], dict):
+        print(f"Kline is a DICT (key access works)")
+        print(f"Keys: {list(raw_list[0].keys())}")
+
+session.close()

--- a/src/database/facts.py
+++ b/src/database/facts.py
@@ -52,7 +52,6 @@ class FactLoader:
                 volume DOUBLE,
                 turnover DOUBLE,
                 open_interest DOUBLE,
-                open_interest_value DOUBLE,
                 funding_rate DOUBLE,
                 daily_volatility DOUBLE,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -94,7 +93,7 @@ class FactLoader:
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value, funding_rate, daily_volatility
+                open_interest, funding_rate, daily_volatility
             )
             SELECT
                 ROW_NUMBER() OVER (ORDER BY s.date) + {max_id} AS price_id,
@@ -109,7 +108,6 @@ class FactLoader:
                 s.volume,
                 NULL AS turnover,
                 NULL AS open_interest,
-                NULL AS open_interest_value,
                 NULL AS funding_rate,
                 (s.high - s.low) AS daily_volatility
             FROM clean_yahoo_stocks s
@@ -138,7 +136,7 @@ class FactLoader:
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value, funding_rate, daily_volatility
+                open_interest, funding_rate, daily_volatility
             )
             SELECT
                 ROW_NUMBER() OVER (ORDER BY c.date) + {max_id} AS price_id,
@@ -153,7 +151,6 @@ class FactLoader:
                 c.volume,
                 c.turnover,
                 c.open_interest,
-                c.open_interest_value,
                 c.funding_rate,
                 (c.high - c.low) AS daily_volatility
             FROM clean_bybit_crypto c

--- a/src/database/facts.py
+++ b/src/database/facts.py
@@ -53,6 +53,7 @@ class FactLoader:
                 turnover DOUBLE,
                 open_interest DOUBLE,
                 open_interest_value DOUBLE,
+                funding_rate DOUBLE,
                 daily_volatility DOUBLE,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
@@ -93,7 +94,7 @@ class FactLoader:
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value, daily_volatility
+                open_interest, open_interest_value, funding_rate, daily_volatility
             )
             SELECT
                 ROW_NUMBER() OVER (ORDER BY s.date) + {max_id} AS price_id,
@@ -109,6 +110,7 @@ class FactLoader:
                 NULL AS turnover,
                 NULL AS open_interest,
                 NULL AS open_interest_value,
+                NULL AS funding_rate,
                 (s.high - s.low) AS daily_volatility
             FROM clean_yahoo_stocks s
             JOIN dim_assets da ON s.ticker = da.asset_symbol
@@ -136,7 +138,7 @@ class FactLoader:
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value, daily_volatility
+                open_interest, open_interest_value, funding_rate, daily_volatility
             )
             SELECT
                 ROW_NUMBER() OVER (ORDER BY c.date) + {max_id} AS price_id,
@@ -152,6 +154,7 @@ class FactLoader:
                 c.turnover,
                 c.open_interest,
                 c.open_interest_value,
+                c.funding_rate,
                 (c.high - c.low) AS daily_volatility
             FROM clean_bybit_crypto c
             JOIN dim_assets da ON REPLACE(c.symbol, 'USDT', '') = da.asset_symbol

--- a/src/database/facts.py
+++ b/src/database/facts.py
@@ -50,6 +50,9 @@ class FactLoader:
                 low DOUBLE,
                 close DOUBLE,
                 volume DOUBLE,
+                turnover DOUBLE,
+                open_interest DOUBLE,
+                open_interest_value DOUBLE,
                 daily_volatility DOUBLE,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
@@ -89,9 +92,10 @@ class FactLoader:
         self.conn.execute(f"""
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
-                open, high, low, close, volume, daily_volatility
+                open, high, low, close, volume, turnover,
+                open_interest, open_interest_value, daily_volatility
             )
-            SELECT 
+            SELECT
                 ROW_NUMBER() OVER (ORDER BY s.date) + {max_id} AS price_id,
                 da.asset_id,
                 dd.date_id,
@@ -102,6 +106,9 @@ class FactLoader:
                 s.low,
                 s.close,
                 s.volume,
+                NULL AS turnover,
+                NULL AS open_interest,
+                NULL AS open_interest_value,
                 (s.high - s.low) AS daily_volatility
             FROM clean_yahoo_stocks s
             JOIN dim_assets da ON s.ticker = da.asset_symbol
@@ -128,9 +135,10 @@ class FactLoader:
         self.conn.execute(f"""
             INSERT INTO fact_price_history (
                 price_id, asset_id, date_id, interval_id, timestamp,
-                open, high, low, close, volume, daily_volatility
+                open, high, low, close, volume, turnover,
+                open_interest, open_interest_value, daily_volatility
             )
-            SELECT 
+            SELECT
                 ROW_NUMBER() OVER (ORDER BY c.date) + {max_id} AS price_id,
                 da.asset_id,
                 dd.date_id,
@@ -141,6 +149,9 @@ class FactLoader:
                 c.low,
                 c.close,
                 c.volume,
+                c.turnover,
+                c.open_interest,
+                c.open_interest_value,
                 (c.high - c.low) AS daily_volatility
             FROM clean_bybit_crypto c
             JOIN dim_assets da ON REPLACE(c.symbol, 'USDT', '') = da.asset_symbol

--- a/src/database/loader.py
+++ b/src/database/loader.py
@@ -113,7 +113,7 @@ class DatabaseLoader:
                             '{symbol}' as symbol,
                             '{readable_interval}' as interval,
                             date, open, high, low, close, volume, turnover,
-                            open_interest, open_interest_value
+                            open_interest, open_interest_value, funding_rate
                         FROM read_parquet('{file_path}')
                     """)
                     self.logger.info(f"Loaded {symbol} [{interval}] from S3")

--- a/src/database/loader.py
+++ b/src/database/loader.py
@@ -90,7 +90,10 @@ class DatabaseLoader:
                 high DOUBLE,
                 low DOUBLE,
                 close DOUBLE,
-                volume DOUBLE
+                volume DOUBLE,
+                turnover DOUBLE,
+                open_interest DOUBLE,
+                open_interest_value DOUBLE
             )
         """)
         
@@ -104,11 +107,12 @@ class DatabaseLoader:
                 file_path = f"s3://{self.s3_bucket}/{symbol}_{readable_interval}.parquet"
                 try:
                     self.conn.execute(f"""
-                        INSERT INTO bybit_crypto 
-                        SELECT 
+                        INSERT INTO bybit_crypto
+                        SELECT
                             '{symbol}' as symbol,
                             '{readable_interval}' as interval,
-                            date, open, high, low, close, volume
+                            date, open, high, low, close, volume, turnover,
+                            open_interest, open_interest_value
                         FROM read_parquet('{file_path}')
                     """)
                     self.logger.info(f"Loaded {symbol} [{interval}] from S3")

--- a/src/database/loader.py
+++ b/src/database/loader.py
@@ -93,7 +93,6 @@ class DatabaseLoader:
                 volume DOUBLE,
                 turnover DOUBLE,
                 open_interest DOUBLE,
-                open_interest_value DOUBLE,
                 funding_rate DOUBLE
             )
         """)
@@ -113,7 +112,7 @@ class DatabaseLoader:
                             '{symbol}' as symbol,
                             '{readable_interval}' as interval,
                             date, open, high, low, close, volume, turnover,
-                            open_interest, open_interest_value, funding_rate
+                            open_interest, funding_rate
                         FROM read_parquet('{file_path}')
                     """)
                     self.logger.info(f"Loaded {symbol} [{interval}] from S3")

--- a/src/database/loader.py
+++ b/src/database/loader.py
@@ -93,7 +93,8 @@ class DatabaseLoader:
                 volume DOUBLE,
                 turnover DOUBLE,
                 open_interest DOUBLE,
-                open_interest_value DOUBLE
+                open_interest_value DOUBLE,
+                funding_rate DOUBLE
             )
         """)
         

--- a/src/ingestion/bybit_client.py
+++ b/src/ingestion/bybit_client.py
@@ -115,6 +115,59 @@ class BybitClient:
         self.logger.info(f"  Fetched {len(oi_df)} OI data points")
         return oi_df
 
+    def fetch_funding_rate(self, symbol: str, start_ts: int, end_ts: int):
+        """Fetch historical funding rate data and resample to target interval."""
+        self.logger.info(f"  Fetching Funding Rate for {symbol}...")
+
+        all_fr = []
+        cursor = None
+
+        while True:
+            try:
+                params = {
+                    "category": "linear",
+                    "symbol": symbol,
+                    "limit": 200
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                response = self.session.get_funding_rate_history(**params)
+                raw_list = response.get('result', {}).get('list', [])
+
+                if not raw_list:
+                    break
+
+                for item in raw_list:
+                    ts = int(item[0])
+                    if ts < start_ts:
+                        continue
+                    if ts > end_ts:
+                        continue
+                    all_fr.append({
+                        "timestamp": ts,
+                        "funding_rate": float(item[1])
+                    })
+
+                cursor = response.get('result', {}).get('nextPageCursor')
+                if not cursor:
+                    break
+
+                time.sleep(0.1)
+
+            except Exception as e:
+                self.logger.error(f"  Error fetching funding rate: {e}")
+                break
+
+        if not all_fr:
+            self.logger.info(f"  No funding rate data fetched for {symbol}")
+            return None
+
+        fr_df = pd.DataFrame(all_fr)
+        fr_df = fr_df.sort_values("timestamp").drop_duplicates(subset=["timestamp"])
+        self.logger.info(f"  Fetched {len(fr_df)} funding rate data points")
+        return fr_df
+
     def fetch_data(self, symbol: str):
         """
         Fetches candlestick data from Bybit, enriched with Open Interest.
@@ -205,8 +258,16 @@ class BybitClient:
                 df["open_interest"] = None
                 df["open_interest_value"] = None
 
+            fr_df = self.fetch_funding_rate(symbol, start_ts, end_ts)
+            if fr_df is not None:
+                df = df.merge(fr_df, on="timestamp", how="left")
+                df["funding_rate"] = df["funding_rate"].ffill()
+                self.logger.info(f"  Merged funding rate data: {df['funding_rate'].notna().sum()} non-null rows")
+            else:
+                df["funding_rate"] = None
+
             output_columns = ["date", "open", "high", "low", "close", "volume", "turnover",
-                              "open_interest", "open_interest_value"]
+                              "open_interest", "open_interest_value", "funding_rate"]
             df = df[output_columns]
 
             readable_interval = "1h" if interval == "60" else ("1d" if interval == "D" else interval)

--- a/src/ingestion/bybit_client.py
+++ b/src/ingestion/bybit_client.py
@@ -47,9 +47,77 @@ class BybitClient:
             if conn:
                 conn.close()
     
+    def _map_to_oi_interval(self, kline_interval: str):
+        """Map kline interval to open interest interval supported by Bybit API"""
+        mapping = {
+            "60": "1h",
+            "D": "1d",
+        }
+        return mapping.get(kline_interval)
+
+    def fetch_open_interest(self, symbol: str, interval: str, start_ts: int, end_ts: int):
+        """Fetch open interest data for a symbol, aligned to the given interval."""
+        oi_interval = self._map_to_oi_interval(interval)
+        if oi_interval is None:
+            self.logger.info(f"  No OI interval mapping for {interval}, skipping OI fetch")
+            return None
+
+        self.logger.info(f"  Fetching Open Interest for {symbol} at {oi_interval}...")
+
+        all_oi = []
+        cursor = None
+
+        while True:
+            try:
+                params = {
+                    "category": "linear",
+                    "symbol": symbol,
+                    "intervalTime": oi_interval,
+                    "limit": 200
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                response = self.session.get_open_interest(**params)
+                raw_list = response.get('result', {}).get('list', [])
+
+                if not raw_list:
+                    break
+
+                for item in raw_list:
+                    ts = int(item[0])
+                    if ts < start_ts:
+                        continue
+                    if ts > end_ts:
+                        continue
+                    all_oi.append({
+                        "timestamp": ts,
+                        "open_interest": float(item[1]),
+                        "open_interest_value": float(item[2])
+                    })
+
+                cursor = response.get('result', {}).get('nextPageCursor')
+                if not cursor:
+                    break
+
+                time.sleep(0.1)
+
+            except Exception as e:
+                self.logger.error(f"  Error fetching OI: {e}")
+                break
+
+        if not all_oi:
+            self.logger.info(f"  No OI data fetched for {symbol}")
+            return None
+
+        oi_df = pd.DataFrame(all_oi)
+        oi_df = oi_df.sort_values("timestamp").drop_duplicates(subset=["timestamp"])
+        self.logger.info(f"  Fetched {len(oi_df)} OI data points")
+        return oi_df
+
     def fetch_data(self, symbol: str):
         """
-        Fetches candlestick data from Bybit.
+        Fetches candlestick data from Bybit, enriched with Open Interest.
         """
         provider_config = self.config["providers"]["bybit"]
         intervals = provider_config.get("intervals", ["60"])
@@ -73,7 +141,7 @@ class BybitClient:
             self.logger.info(f"Time Range: {datetime.fromtimestamp(start_ts/1000)} to Now ({start_ts} to {end_ts})")
 
             all_data = []
-            cursor_end = end_ts 
+            cursor_end = end_ts
             
             while cursor_end > start_ts:
                 try:
@@ -126,8 +194,20 @@ class BybitClient:
             df["date"] = pd.to_datetime(df["timestamp"], unit="ms")
             
             df = df.sort_values(by="date").reset_index(drop=True)
-            
-            df = df[["date", "open", "high", "low", "close", "volume"]]
+
+            oi_df = self.fetch_open_interest(symbol, interval, start_ts, end_ts)
+            if oi_df is not None:
+                df = df.merge(oi_df, on="timestamp", how="left")
+                df["open_interest"] = df["open_interest"].ffill()
+                df["open_interest_value"] = df["open_interest_value"].ffill()
+                self.logger.info(f"  Merged OI data: {df['open_interest'].notna().sum()} non-null rows")
+            else:
+                df["open_interest"] = None
+                df["open_interest_value"] = None
+
+            output_columns = ["date", "open", "high", "low", "close", "volume", "turnover",
+                              "open_interest", "open_interest_value"]
+            df = df[output_columns]
 
             readable_interval = "1h" if interval == "60" else ("1d" if interval == "D" else interval)
             

--- a/src/ingestion/bybit_client.py
+++ b/src/ingestion/bybit_client.py
@@ -90,10 +90,10 @@ class BybitClient:
                         continue
                     if ts > end_ts:
                         continue
+                    oi_value = float(item["openInterest"])
                     all_oi.append({
                         "timestamp": ts,
-                        "open_interest": float(item["openInterest"]),
-                        "open_interest_value": float(item["openInterestValue"])
+                        "open_interest": oi_value
                     })
 
                 cursor = response.get('result', {}).get('nextPageCursor')
@@ -139,7 +139,7 @@ class BybitClient:
                     break
 
                 for item in raw_list:
-                    ts = int(item["timestamp"])
+                    ts = int(item["fundingRateTimestamp"])
                     if ts < start_ts:
                         continue
                     if ts > end_ts:
@@ -264,11 +264,9 @@ class BybitClient:
             if oi_df is not None:
                 df = df.merge(oi_df, on="timestamp", how="left")
                 df["open_interest"] = df["open_interest"].ffill()
-                df["open_interest_value"] = df["open_interest_value"].ffill()
                 self.logger.info(f"  Merged OI data: {df['open_interest'].notna().sum()} non-null rows")
             else:
                 df["open_interest"] = None
-                df["open_interest_value"] = None
 
             fr_df = self.fetch_funding_rate(symbol, start_ts, end_ts)
             if fr_df is not None:
@@ -279,7 +277,7 @@ class BybitClient:
                 df["funding_rate"] = None
 
             output_columns = ["date", "open", "high", "low", "close", "volume", "turnover",
-                              "open_interest", "open_interest_value", "funding_rate"]
+                              "open_interest", "funding_rate"]
             df = df[output_columns]
 
             readable_interval = "1h" if interval == "60" else ("1d" if interval == "D" else interval)

--- a/src/ingestion/bybit_client.py
+++ b/src/ingestion/bybit_client.py
@@ -196,6 +196,9 @@ class BybitClient:
             all_data = []
             cursor_end = end_ts
             
+            rate_limit_retries = 0
+            max_rate_limit_retries = 5
+
             while cursor_end > start_ts:
                 try:
                     response = self.session.get_kline(
@@ -229,10 +232,19 @@ class BybitClient:
                     
                     self.logger.info(f"Fetched {len(batch_df)} rows. Oldest in batch: {datetime.fromtimestamp(min_ts/1000)}")
                     time.sleep(0.1)
+                    
+                    rate_limit_retries = 0
 
                 except Exception as e:
-                    self.logger.error(f"Error fetching {symbol} [{interval}]: {e}")
-                    break
+                    error_str = str(e)
+                    if "ErrCode: 10006" in error_str and rate_limit_retries < max_rate_limit_retries:
+                        rate_limit_retries += 1
+                        wait_time = 2 ** rate_limit_retries
+                        self.logger.warning(f"Rate limited on {symbol} [{interval}]. Retry {rate_limit_retries}/{max_rate_limit_retries}, waiting {wait_time}s...")
+                        time.sleep(wait_time)
+                    else:
+                        self.logger.error(f"Error fetching {symbol} [{interval}]: {e}")
+                        break
 
             if not all_data:
                  self.logger.warning(f"No new data found for {symbol} at interval {interval}")

--- a/src/ingestion/bybit_client.py
+++ b/src/ingestion/bybit_client.py
@@ -85,15 +85,15 @@ class BybitClient:
                     break
 
                 for item in raw_list:
-                    ts = int(item[0])
+                    ts = int(item["timestamp"])
                     if ts < start_ts:
                         continue
                     if ts > end_ts:
                         continue
                     all_oi.append({
                         "timestamp": ts,
-                        "open_interest": float(item[1]),
-                        "open_interest_value": float(item[2])
+                        "open_interest": float(item["openInterest"]),
+                        "open_interest_value": float(item["openInterestValue"])
                     })
 
                 cursor = response.get('result', {}).get('nextPageCursor')
@@ -139,14 +139,14 @@ class BybitClient:
                     break
 
                 for item in raw_list:
-                    ts = int(item[0])
+                    ts = int(item["timestamp"])
                     if ts < start_ts:
                         continue
                     if ts > end_ts:
                         continue
                     all_fr.append({
                         "timestamp": ts,
-                        "funding_rate": float(item[1])
+                        "funding_rate": float(item["fundingRate"])
                     })
 
                 cursor = response.get('result', {}).get('nextPageCursor')

--- a/src/ingestion/yahoo_finance.py
+++ b/src/ingestion/yahoo_finance.py
@@ -28,6 +28,7 @@ class YahooFinanceClient:
         self.session.headers.update({
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
         })
+        self._rate_limited = False
 
     def get_last_fetched_date(self, ticker: str, interval: str):
         """Query DuckDB for the latest date of fetched data for the given ticker and interval."""
@@ -57,6 +58,10 @@ class YahooFinanceClient:
         intervals = self.config["providers"]["yfinance"]["intervals"] 
         
         for interval in intervals:
+            if self._rate_limited:
+                self.logger.warning(f"Yahoo Finance rate limit detected earlier — skipping {ticker} [{interval}] (existing data will be used)")
+                continue
+
             self.logger.info(f"Fetching data for {ticker} using yfinance... [{interval}]")
             
             last_date = self.get_last_fetched_date(ticker, interval)
@@ -73,7 +78,7 @@ class YahooFinanceClient:
                         start_date = limit_date
             
             try:
-                max_retries = 8
+                max_retries = 2
                 retry_count = 0
                 df = pd.DataFrame()
                 
@@ -108,23 +113,22 @@ class YahooFinanceClient:
                         retry_count += 1
 
                     except YFRateLimitError as e:
-                        retry_count += 1
-                        wait_time = (2 ** retry_count) * 10
+                        self._rate_limited = True
                         self.logger.warning(
-                            f"Yahoo rate limited for {ticker} [{interval}]. "
-                            f"Retry {retry_count}/{max_retries}, waiting {wait_time}s..."
+                            f"Yahoo Finance rate limited for {ticker} [{interval}]. "
+                            f"IP-level block detected — skipping all remaining Yahoo fetches. "
+                            f"Existing data in S3 will be used by the loader."
                         )
-                        time.sleep(wait_time)
+                        break
 
                     except Exception as e:
                         if "429" in str(e) or "Rate limit" in str(e) or "Too Many Requests" in str(e):
-                            retry_count += 1
-                            wait_time = (2 ** retry_count) * 10
+                            self._rate_limited = True
                             self.logger.warning(
                                 f"HTTP 429 block for {ticker} [{interval}]. "
-                                f"Retry {retry_count}/{max_retries}, waiting {wait_time}s..."
+                                f"IP-level block detected — skipping all remaining Yahoo fetches."
                             )
-                            time.sleep(wait_time)
+                            break
                         else:
                             retry_count += 1
                             self.logger.error(f"Error fetching {ticker} [{interval}] (Attempt {retry_count}): {e}")

--- a/src/ingestion/yahoo_finance.py
+++ b/src/ingestion/yahoo_finance.py
@@ -5,12 +5,13 @@ import pandas as pd
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import yfinance as yf
+from yfinance.exceptions import YFRateLimitError
 import requests
 from src.utils import get_logger
 import duckdb
 from pyrate_limiter import Duration, RequestRate, Limiter
 from requests_cache import CacheMixin, SQLiteCache
-from requests_ratelimiter import  LimiterSession
+from requests_ratelimiter import LimiterSession
 import random
 
 
@@ -72,7 +73,7 @@ class YahooFinanceClient:
                         start_date = limit_date
             
             try:
-                max_retries = 3
+                max_retries = 8
                 retry_count = 0
                 df = pd.DataFrame()
                 
@@ -80,36 +81,54 @@ class YahooFinanceClient:
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
                     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
                 ]
 
                 while retry_count < max_retries:
                     try:
-                        time.sleep(1 + (retry_count * 2)) 
-                        with requests.Session() as fresh_session:
-                            fresh_session.headers.update({"User-Agent": random.choice(USER_AGENTS)})
-                            
-                            df = yf.download(ticker, start=start_date, interval=interval, progress=False, session=fresh_session)
+                        base_wait = 2 ** retry_count
+                        jitter = random.uniform(0.5, 1.5)
+                        time.sleep(base_wait * jitter)
+                        
+                        self.session.headers.update({"User-Agent": random.choice(USER_AGENTS)})
+                        
+                        df = yf.download(ticker, start=start_date, interval=interval, progress=False, session=self.session)
                         
                         if not df.empty:
-                            break  
+                            break
                             
-                        self.logger.warning(f"Empty data or Rate Limited for {ticker} at {interval} (Attempt {retry_count + 1}/{max_retries})")
+                        self.logger.warning(f"Empty data for {ticker} at {interval} (Attempt {retry_count + 1}/{max_retries})")
                         
                         if last_date and (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d") <= start_date:
                             self.logger.info(f"Assuming market is closed (weekend/holiday) and no new data for {ticker} [{interval}]. Moving on.")
                             break
 
                         retry_count += 1
-                        time.sleep(5)
-                    except Exception as e:
-                        if "429" in str(e) or "Rate limit" in str(e):
-                            self.logger.warning(f"Hard 429 block for {ticker} at {interval} (Attempt {retry_count + 1}/{max_retries})")
-                            time.sleep(10)
-                        else:
-                            self.logger.error(f"Error fetching {ticker} at {interval} (Attempt {retry_count + 1}): {e}")
-                            time.sleep(3)
+
+                    except YFRateLimitError as e:
                         retry_count += 1
+                        wait_time = (2 ** retry_count) * 10
+                        self.logger.warning(
+                            f"Yahoo rate limited for {ticker} [{interval}]. "
+                            f"Retry {retry_count}/{max_retries}, waiting {wait_time}s..."
+                        )
+                        time.sleep(wait_time)
+
+                    except Exception as e:
+                        if "429" in str(e) or "Rate limit" in str(e) or "Too Many Requests" in str(e):
+                            retry_count += 1
+                            wait_time = (2 ** retry_count) * 10
+                            self.logger.warning(
+                                f"HTTP 429 block for {ticker} [{interval}]. "
+                                f"Retry {retry_count}/{max_retries}, waiting {wait_time}s..."
+                            )
+                            time.sleep(wait_time)
+                        else:
+                            retry_count += 1
+                            self.logger.error(f"Error fetching {ticker} [{interval}] (Attempt {retry_count}): {e}")
+                            time.sleep(5)
                 
                 if df.empty:
                     self.logger.error(f"Failed to fetch {ticker} [{interval}] after {max_retries} retries. Skipping.")

--- a/src/models/logics.py
+++ b/src/models/logics.py
@@ -62,8 +62,7 @@ class GoldLayerProcessor:
             SELECT
                 da.asset_symbol, da.asset_class, da.exchange,
                 di.interval_code AS interval, f.timestamp AS date,
-                f.open, f.high, f.low, f.close, f.volume, f.turnover,
-                f.open_interest, f.open_interest_value, f.daily_volatility,
+                f.open, f.high, f.low, f.close, f.volume, f.daily_volatility,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS sma_7,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS sma_30
             FROM fact_price_history f

--- a/src/models/logics.py
+++ b/src/models/logics.py
@@ -45,7 +45,7 @@ class GoldLayerProcessor:
                 da.asset_symbol, da.asset_class, da.exchange,
                 di.interval_code AS interval, f.timestamp AS date,
                 f.open, f.high, f.low, f.close, f.volume, f.turnover,
-                f.open_interest, f.open_interest_value, f.daily_volatility,
+                f.open_interest, f.open_interest_value, f.funding_rate, f.daily_volatility,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS sma_7,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS sma_30
             FROM fact_price_history f

--- a/src/models/logics.py
+++ b/src/models/logics.py
@@ -45,7 +45,7 @@ class GoldLayerProcessor:
                 da.asset_symbol, da.asset_class, da.exchange,
                 di.interval_code AS interval, f.timestamp AS date,
                 f.open, f.high, f.low, f.close, f.volume, f.turnover,
-                f.open_interest, f.open_interest_value, f.funding_rate, f.daily_volatility,
+                f.open_interest, f.funding_rate, f.daily_volatility,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS sma_7,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS sma_30
             FROM fact_price_history f

--- a/src/models/logics.py
+++ b/src/models/logics.py
@@ -41,10 +41,11 @@ class GoldLayerProcessor:
         self.conn.execute("DROP TABLE IF EXISTS gold_crypto_analytics")
         self.conn.execute("""
             CREATE TABLE gold_crypto_analytics AS
-            SELECT 
+            SELECT
                 da.asset_symbol, da.asset_class, da.exchange,
                 di.interval_code AS interval, f.timestamp AS date,
-                f.open, f.high, f.low, f.close, f.volume, f.daily_volatility,
+                f.open, f.high, f.low, f.close, f.volume, f.turnover,
+                f.open_interest, f.open_interest_value, f.daily_volatility,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS sma_7,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS sma_30
             FROM fact_price_history f
@@ -58,10 +59,11 @@ class GoldLayerProcessor:
         self.conn.execute("DROP TABLE IF EXISTS gold_stock_analytics")
         self.conn.execute("""
             CREATE TABLE gold_stock_analytics AS
-            SELECT 
+            SELECT
                 da.asset_symbol, da.asset_class, da.exchange,
                 di.interval_code AS interval, f.timestamp AS date,
-                f.open, f.high, f.low, f.close, f.volume, f.daily_volatility,
+                f.open, f.high, f.low, f.close, f.volume, f.turnover,
+                f.open_interest, f.open_interest_value, f.daily_volatility,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) AS sma_7,
                 AVG(f.close) OVER (PARTITION BY da.asset_symbol, di.interval_code ORDER BY f.timestamp ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS sma_30
             FROM fact_price_history f

--- a/src/models/technical_indicators.py
+++ b/src/models/technical_indicators.py
@@ -109,20 +109,23 @@ class TechnicalIndicatorProcessor:
         self.logger.info("=" * 60)
         self.logger.info("Building Specialized Gold Feature Stores")
         self.logger.info("=" * 60)
-        
         query = """
             SELECT asset_symbol, asset_class, exchange, interval, date,
-                   open, high, low, close, volume, daily_volatility, sma_7, sma_30,
-                   turnover, open_interest, open_interest_value, funding_rate
+                   open, high, low, close, volume, daily_volatility, sma_7, sma_30
             FROM gold_crypto_analytics
             UNION ALL
             SELECT asset_symbol, asset_class, exchange, interval, date,
-                   open, high, low, close, volume, daily_volatility, sma_7, sma_30,
-                   NULL as turnover, NULL as open_interest, NULL as open_interest_value, NULL as funding_rate
+                   open, high, low, close, volume, daily_volatility, sma_7, sma_30
             FROM gold_stock_analytics
         """
         df_all = self.conn.execute(query).df()
         self.logger.info(f"Loaded {len(df_all)} rows from specialized intermediate layers")
+
+        crypto_extra = self.conn.execute("""
+            SELECT asset_symbol, interval, date,
+                   turnover, open_interest, funding_rate
+            FROM gold_crypto_analytics
+        """).df()
 
         result_dfs = []
         total_groups = df_all.groupby(['asset_symbol', 'interval']).ngroups
@@ -149,7 +152,21 @@ class TechnicalIndicatorProcessor:
         for asset_class in final_df['asset_class'].unique():
             class_df = final_df[final_df['asset_class'] == asset_class].copy()
             initial_rows = len(class_df)
-            class_df = class_df.dropna()
+            indicator_cols = ['rsi_14', 'macd', 'macd_signal', 'macd_histogram', 'roc_10', 'roc_20',
+                              'stoch_k', 'stoch_d', 'ema_12', 'ema_26', 'ema_50', 'ema_200',
+                              'sma_50', 'sma_100', 'sma_200', 'bb_upper', 'bb_middle', 'bb_lower',
+                              'bb_width', 'bb_percentage', 'atr_14', 'obv', 'vwap',
+                              'volume_sma_20', 'volume_ratio', 'returns_1p', 'returns_5p',
+                              'returns_10p', 'returns_20p', 'log_returns', 'hl_ratio', 'close_position']
+            cols_to_check = [c for c in indicator_cols if c in class_df.columns]
+            class_df = class_df.dropna(subset=cols_to_check)
+            
+            if asset_class.lower() == 'crypto':
+                merge_keys = ['asset_symbol', 'interval', 'date']
+                class_df = class_df.merge(
+                    crypto_extra[merge_keys + ['turnover', 'open_interest', 'funding_rate']],
+                    on=merge_keys, how='left'
+                )
             
             self.logger.info(f"--- Processing {asset_class.upper()} Gold Store ---")
             self.logger.info(f"Dropped {initial_rows - len(class_df)} rows with NaNs (warm-up)")

--- a/src/models/technical_indicators.py
+++ b/src/models/technical_indicators.py
@@ -111,9 +111,15 @@ class TechnicalIndicatorProcessor:
         self.logger.info("=" * 60)
         
         query = """
-            SELECT * FROM gold_crypto_analytics
+            SELECT asset_symbol, asset_class, exchange, interval, date,
+                   open, high, low, close, volume, daily_volatility, sma_7, sma_30,
+                   turnover, open_interest, open_interest_value, funding_rate
+            FROM gold_crypto_analytics
             UNION ALL
-            SELECT * FROM gold_stock_analytics
+            SELECT asset_symbol, asset_class, exchange, interval, date,
+                   open, high, low, close, volume, daily_volatility, sma_7, sma_30,
+                   NULL as turnover, NULL as open_interest, NULL as open_interest_value, NULL as funding_rate
+            FROM gold_stock_analytics
         """
         df_all = self.conn.execute(query).df()
         self.logger.info(f"Loaded {len(df_all)} rows from specialized intermediate layers")

--- a/src/processing/transformation.py
+++ b/src/processing/transformation.py
@@ -75,7 +75,7 @@ class DataCleaner:
                 interval,
                 CAST(date AS TIMESTAMP) AS date,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value
+                open_interest, open_interest_value, funding_rate
             FROM (
                 SELECT *,
                     ROW_NUMBER() OVER (PARTITION BY symbol, interval, date ORDER BY volume DESC) AS rn

--- a/src/processing/transformation.py
+++ b/src/processing/transformation.py
@@ -70,11 +70,12 @@ class DataCleaner:
         self.conn.execute("DROP TABLE IF EXISTS clean_bybit_crypto")
         self.conn.execute("""
             CREATE TABLE clean_bybit_crypto AS
-            SELECT 
+            SELECT
                 symbol,
                 interval,
                 CAST(date AS TIMESTAMP) AS date,
-                open, high, low, close, volume
+                open, high, low, close, volume, turnover,
+                open_interest, open_interest_value
             FROM (
                 SELECT *,
                     ROW_NUMBER() OVER (PARTITION BY symbol, interval, date ORDER BY volume DESC) AS rn

--- a/src/processing/transformation.py
+++ b/src/processing/transformation.py
@@ -75,7 +75,7 @@ class DataCleaner:
                 interval,
                 CAST(date AS TIMESTAMP) AS date,
                 open, high, low, close, volume, turnover,
-                open_interest, open_interest_value, funding_rate
+                open_interest, funding_rate
             FROM (
                 SELECT *,
                     ROW_NUMBER() OVER (PARTITION BY symbol, interval, date ORDER BY volume DESC) AS rn


### PR DESCRIPTION
eda: evaluate new OI/funding rate/turnover columns for ML 

- Ran coverage analysis across all 11 crypto symbols × 4 intervals
- OI: 95-100% coverage on 1h/1d, 0% on W/M (Bybit limitation)
- OI spikes predict 24× baseline returns — engineer oi_change as feature
- Funding rate: 97% NaN, only 2 months of history — skip for now
- Turnover: 100% coverage, comes from Bybit kline API directly
- Updated eda_insight_btc_1hr.md with findings and ML feature plan

- Close #86 