### PR TITLE
103 build plotly dash web dashboard multi tab UI from duckdb gold tables

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -71,80 +71,51 @@ def render_tab(active_tab: str):
     return html.P("Select a tab.", className="text-muted")
 
 def render_price_dashboard():
-    """BTC/USDT candlestick chart + volume bars from gold_crypto_analytics."""
+    """BTC/USDT candlestick chart with time-range selector (default: 7 days for performance)."""
     try:
-        conn = duckdb.connect(DB_PATH, read_only=True)
-        df = conn.execute("""
-            SELECT date, open, high, low, close, volume
-            FROM gold_crypto_analytics
-            WHERE asset_symbol = 'BTC' AND interval = '1h'
-            ORDER BY date
-        """).df()
-        conn.close()
-
-        if df.empty:
-            return dbc.Alert("No data found in gold_crypto_analytics for BTC 1h.", color="warning")
-
-        df["date"] = pd.to_datetime(df["date"])
-
-        fig = make_subplots(
-            rows=2, cols=1,
-            shared_xaxes=True,
-            vertical_spacing=0.03,
-            row_heights=[0.7, 0.3],
-            subplot_titles=("BTC/USDT — 1H Candlesticks", "Volume"),
-        )
-
-        fig.add_trace(
-            go.Candlestick(
-                x=df["date"],
-                open=df["open"],
-                high=df["high"],
-                low=df["low"],
-                close=df["close"],
-                name="BTC/USDT",
-                increasing_line_color="#26a69a",
-                decreasing_line_color="#ef5350",
-            ),
-            row=1, col=1,
-        )
-
-        colors = ["#26a69a" if c >= o else "#ef5350" for o, c in zip(df["open"], df["close"])]
-        fig.add_trace(
-            go.Bar(
-                x=df["date"],
-                y=df["volume"],
-                name="Volume",
-                marker_color=colors,
-                opacity=0.6,
-            ),
-            row=2, col=1,
-        )
-
-        fig.update_layout(
-            template="plotly_dark",
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor="rgba(0,0,0,0)",
-            height=700,
-            hovermode="x unified",
-            showlegend=False,
-            margin=dict(l=10, r=10, t=40, b=10),
-            xaxis_rangeslider_visible=False,
-        )
-        fig.update_yaxes(title_text="Price (USD)", row=1, col=1)
-        fig.update_yaxes(title_text="Volume", row=2, col=1)
+        range_options = [
+            {"label": "1 Day", "value": "1d"},
+            {"label": "3 Days", "value": "3d"},
+            {"label": "1 Week", "value": "7d"},
+            {"label": "1 Month", "value": "30d"},
+            {"label": "3 Months", "value": "90d"},
+            {"label": "6 Months", "value": "180d"},
+            {"label": "1 Year", "value": "365d"},
+            {"label": "All Data", "value": "all"},
+        ]
 
         return dbc.Row(
             dbc.Col(
                 [
-                    html.H3(" BTC/USDT — Price History", className="text-light mb-3"),
-                    dcc.Graph(figure=fig, config={"displayModeBar": True, "responsive": True}),
+                    html.H3("BTC/USDT — Price History", className="text-light mb-3"),
+                    dbc.Row(
+                        dbc.Col(
+                            dcc.Dropdown(
+                                id="price-range-dropdown",
+                                options=range_options,
+                                value="7d",
+                                clearable=False,
+                                searchable=False,
+                                className="mb-3",
+                                style={"color": "#000"},
+                            ),
+                            width=3,
+                        ),
+                    ),
+                    dcc.Loading(
+                        id="loading-price",
+                        type="circle",
+                        children=dcc.Graph(
+                            id="price-chart",
+                            config={"displayModeBar": True, "responsive": True},
+                        ),
+                    ),
                 ],
                 width=12,
             )
         )
     except Exception as e:
-        return dbc.Alert(f"Error loading price dashboard: {e}", color="danger")
+        return dbc.Alert(f"Error: {e}", color="danger")
 
 def render_predictions():
     """XGBoost model predictions: actual vs predicted direction chart, accuracy, and confidence distribution."""
@@ -483,5 +454,147 @@ def update_explorer_table(table_name):
     except Exception as e:
         return dbc.Alert(f"Error loading table '{table_name}': {e}", color="danger"), ""
     
+PRICE_RANGE_MAP = {
+    "1d": 1, "3d": 3, "7d": 7, "30d": 30,
+    "90d": 90, "180d": 180, "365d": 365,
+}
+
+MAX_CANDLES_DISPLAY = 2000
+
+
+def _downsample_ohlcv(df, max_points):
+    """Downsample OHLCV data by merging candles so total points <= max_points."""
+    n = len(df)
+    if n <= max_points:
+        return df
+
+    group_size = (n + max_points - 1) // max_points
+    df = df.copy()
+    df["_group"] = df.index // group_size
+
+    resampled = df.groupby("_group").agg(
+        date=("date", "first"),
+        open=("open", "first"),
+        high=("high", "max"),
+        low=("low", "min"),
+        close=("close", "last"),
+        volume=("volume", "sum"),
+    ).reset_index(drop=True)
+
+    return resampled
+
+
+@app.callback(
+    dash.Output("price-chart", "figure"),
+    dash.Input("price-range-dropdown", "value"),
+)
+def build_price_chart(range_value):
+    """Query the database, downsample if needed, and build the OHLCV figure."""
+    conn = duckdb.connect(DB_PATH, read_only=True)
+
+    if range_value == "all":
+        df = conn.execute("""
+            SELECT date, open, high, low, close, volume
+            FROM gold_crypto_analytics
+            WHERE asset_symbol = 'BTC' AND interval = '1h'
+            ORDER BY date
+        """).df()
+    else:
+        days = PRICE_RANGE_MAP[range_value]
+        df = conn.execute(f"""
+            SELECT date, open, high, low, close, volume
+            FROM gold_crypto_analytics
+            WHERE asset_symbol = 'BTC' AND interval = '1h'
+              AND date >= (SELECT MAX(date) FROM gold_crypto_analytics
+                           WHERE asset_symbol = 'BTC' AND interval = '1h')
+                           - INTERVAL '{days} days'
+            ORDER BY date
+        """).df()
+
+    conn.close()
+
+    if df.empty:
+        return go.Figure().update_layout(
+            template="plotly_dark",
+            title="No data available",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+        )
+
+    df["date"] = pd.to_datetime(df["date"])
+
+    original_count = len(df)
+    df = _downsample_ohlcv(df, MAX_CANDLES_DISPLAY)
+
+    fig = make_subplots(
+        rows=2, cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.03,
+        row_heights=[0.7, 0.3],
+        subplot_titles=(
+            f"BTC/USDT — 1H Candlesticks ({len(df)} candles, from {original_count} raw)",
+            "Volume",
+        ),
+    )
+
+    fig.add_trace(
+        go.Candlestick(
+            x=df["date"],
+            open=df["open"],
+            high=df["high"],
+            low=df["low"],
+            close=df["close"],
+            name="BTC/USDT",
+            increasing_line_color="#26a69a",
+            decreasing_line_color="#ef5350",
+        ),
+        row=1, col=1,
+    )
+
+    colors = ["#26a69a" if c >= o else "#ef5350" for o, c in zip(df["open"], df["close"])]
+    fig.add_trace(
+        go.Bar(
+            x=df["date"],
+            y=df["volume"],
+            name="Volume",
+            marker_color=colors,
+            opacity=0.6,
+        ),
+        row=2, col=1,
+    )
+
+    fig.update_layout(
+        template="plotly_dark",
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        height=700,
+        hovermode="x unified",
+        showlegend=False,
+        margin=dict(l=10, r=10, t=40, b=10),
+        xaxis_rangeslider_visible=True,
+        xaxis=dict(
+            rangeselector=dict(
+                buttons=list([
+                    dict(count=1, label="1d", step="day", stepmode="backward"),
+                    dict(count=3, label="3d", step="day", stepmode="backward"),
+                    dict(count=7, label="1w", step="day", stepmode="backward"),
+                    dict(count=1, label="1m", step="month", stepmode="backward"),
+                    dict(count=3, label="3m", step="month", stepmode="backward"),
+                    dict(count=6, label="6m", step="month", stepmode="backward"),
+                    dict(count=1, label="1y", step="year", stepmode="backward"),
+                    dict(step="all", label="All"),
+                ]),
+                bgcolor="#2a2a2a",
+                activecolor="#375a7f",
+                font=dict(color="#aaa"),
+            ),
+        ),
+    )
+    fig.update_yaxes(title_text="Price (USD)", row=1, col=1)
+    fig.update_yaxes(title_text="Volume", row=2, col=1)
+
+    return fig
+
+
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0", port=8050)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,15 @@
+"""
+Financial Data Analyzer — Plotly Dash Dashboard
+Multi-tab web UI reading directly from DuckDB gold tables.
+"""
+
+import dash
+from dash import dcc, html
+import dash_bootstrap_components as dbc
+import duckdb
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_PATH = os.path.join("database", "financial_data.duckdb")

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -71,7 +71,7 @@ def render_tab(active_tab: str):
     return html.P("Select a tab.", className="text-muted")
 
 def render_price_dashboard():
-    """BTC/USDT candlestick chart with time-range selector (default: 7 days for performance)."""
+    """Multi-asset candlestick chart with asset class, asset, interval, and time-range selectors."""
     try:
         range_options = [
             {"label": "1 Day", "value": "1d"},
@@ -87,20 +87,66 @@ def render_price_dashboard():
         return dbc.Row(
             dbc.Col(
                 [
-                    html.H3("BTC/USDT — Price History", className="text-light mb-3"),
+                    html.H3("Price Dashboard", className="text-light mb-3"),
                     dbc.Row(
-                        dbc.Col(
-                            dcc.Dropdown(
-                                id="price-range-dropdown",
-                                options=range_options,
-                                value="7d",
-                                clearable=False,
-                                searchable=False,
-                                className="mb-3",
-                                style={"color": "#000"},
+                        [
+                            dbc.Col(
+                                [
+                                    html.Label("Asset Class", className="text-muted small mb-1"),
+                                    dcc.Dropdown(
+                                        id="price-class-dropdown",
+                                        options=[
+                                            {"label": "Crypto", "value": "crypto"},
+                                            {"label": "Stocks", "value": "stocks"},
+                                        ],
+                                        value="crypto",
+                                        clearable=False,
+                                        searchable=False,
+                                        style={"color": "#000"},
+                                    ),
+                                ],
+                                width=2,
                             ),
-                            width=3,
-                        ),
+                            dbc.Col(
+                                [
+                                    html.Label("Asset", className="text-muted small mb-1"),
+                                    dcc.Dropdown(
+                                        id="price-asset-dropdown",
+                                        clearable=False,
+                                        searchable=True,
+                                        style={"color": "#000"},
+                                    ),
+                                ],
+                                width=2,
+                            ),
+                            dbc.Col(
+                                [
+                                    html.Label("Interval", className="text-muted small mb-1"),
+                                    dcc.Dropdown(
+                                        id="price-interval-dropdown",
+                                        clearable=False,
+                                        searchable=False,
+                                        style={"color": "#000"},
+                                    ),
+                                ],
+                                width=2,
+                            ),
+                            dbc.Col(
+                                [
+                                    html.Label("Time Range", className="text-muted small mb-1"),
+                                    dcc.Dropdown(
+                                        id="price-range-dropdown",
+                                        options=range_options,
+                                        value="7d",
+                                        clearable=False,
+                                        searchable=False,
+                                        style={"color": "#000"},
+                                    ),
+                                ],
+                                width=2,
+                            ),
+                        ],
+                        className="mb-3",
                     ),
                     dcc.Loading(
                         id="loading-price",
@@ -401,7 +447,6 @@ def render_explorer():
         dbc.Row(dbc.Col(html.Div(id="explorer-table-container"), width=12)),
     ])
 
-
 @app.callback(
     dash.Output("explorer-table-container", "children"),
     dash.Output("explorer-row-count", "children"),
@@ -461,6 +506,34 @@ PRICE_RANGE_MAP = {
 
 MAX_CANDLES_DISPLAY = 2000
 
+CRYPTO_INTERVALS = ["1h", "4h", "1d", "W", "M"]
+STOCK_INTERVALS  = ["1h", "1d", "1wk", "1mo"]
+
+INTERVAL_LABELS = {
+    "1h": "1 Hour",
+    "4h": "4 Hours",
+    "1d": "1 Day",
+    "W":  "1 Week",
+    "M":  "1 Month",
+    "1wk": "1 Week",
+    "1mo": "1 Month",
+}
+
+def _load_asset_list():
+    """Read all distinct crypto symbols from DuckDB (gold_crypto_analytics)."""
+    try:
+        conn = duckdb.connect(DB_PATH, read_only=True)
+        crypto = conn.execute(
+            "SELECT DISTINCT asset_symbol FROM gold_crypto_analytics ORDER BY asset_symbol"
+        ).df()["asset_symbol"].tolist()
+        conn.close()
+        return crypto
+    except Exception:
+        return ["BTC"]
+
+CRYPTO_ASSETS = _load_asset_list()
+STOCK_ASSETS  = ["AAPL", "AMZN", "GOOGL", "META", "MSFT", "TSLA"]
+
 
 def _downsample_ohlcv(df, max_points):
     """Downsample OHLCV data by merging candles so total points <= max_points."""
@@ -483,40 +556,88 @@ def _downsample_ohlcv(df, max_points):
 
     return resampled
 
+@app.callback(
+    dash.Output("price-asset-dropdown", "options"),
+    dash.Output("price-asset-dropdown", "value"),
+    dash.Input("price-class-dropdown", "value"),
+)
+def update_asset_dropdown(asset_class):
+    """When asset class changes, update the asset dropdown with the correct list."""
+    if asset_class == "crypto":
+        assets = CRYPTO_ASSETS
+        default = "BTC" if "BTC" in assets else (assets[0] if assets else None)
+    else:
+        assets = STOCK_ASSETS
+        default = assets[0] if assets else None
+
+    options = [{"label": a, "value": a} for a in assets]
+    return options, default
+
+
+@app.callback(
+    dash.Output("price-interval-dropdown", "options"),
+    dash.Output("price-interval-dropdown", "value"),
+    dash.Input("price-class-dropdown", "value"),
+)
+def update_interval_dropdown(asset_class):
+    """When asset class changes, update the interval dropdown with the correct intervals."""
+    if asset_class == "crypto":
+        intervals = CRYPTO_INTERVALS
+        default = "1h"
+    else:
+        intervals = STOCK_INTERVALS
+        default = "1h"
+
+    options = [{"label": INTERVAL_LABELS.get(iv, iv), "value": iv} for iv in intervals]
+    return options, default
 
 @app.callback(
     dash.Output("price-chart", "figure"),
+    dash.Input("price-class-dropdown", "value"),
+    dash.Input("price-asset-dropdown", "value"),
+    dash.Input("price-interval-dropdown", "value"),
     dash.Input("price-range-dropdown", "value"),
 )
-def build_price_chart(range_value):
+def build_price_chart(asset_class, asset_symbol, interval, range_value):
     """Query the database, downsample if needed, and build the OHLCV figure."""
+
+    if not asset_symbol or not interval or not asset_class:
+        return go.Figure().update_layout(
+            template="plotly_dark",
+            title="Select an asset and interval",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+        )
+
+    table = "gold_crypto_analytics" if asset_class == "crypto" else "gold_stock_analytics"
+
     conn = duckdb.connect(DB_PATH, read_only=True)
 
     if range_value == "all":
-        df = conn.execute("""
+        df = conn.execute(f"""
             SELECT date, open, high, low, close, volume
-            FROM gold_crypto_analytics
-            WHERE asset_symbol = 'BTC' AND interval = '1h'
+            FROM {table}
+            WHERE asset_symbol = ? AND interval = ?
             ORDER BY date
-        """).df()
+        """, [asset_symbol, interval]).df()
     else:
         days = PRICE_RANGE_MAP[range_value]
         df = conn.execute(f"""
             SELECT date, open, high, low, close, volume
-            FROM gold_crypto_analytics
-            WHERE asset_symbol = 'BTC' AND interval = '1h'
-              AND date >= (SELECT MAX(date) FROM gold_crypto_analytics
-                           WHERE asset_symbol = 'BTC' AND interval = '1h')
+            FROM {table}
+            WHERE asset_symbol = ? AND interval = ?
+              AND date >= (SELECT MAX(date) FROM {table}
+                           WHERE asset_symbol = ? AND interval = ?)
                            - INTERVAL '{days} days'
             ORDER BY date
-        """).df()
+        """, [asset_symbol, interval, asset_symbol, interval]).df()
 
     conn.close()
 
     if df.empty:
         return go.Figure().update_layout(
             template="plotly_dark",
-            title="No data available",
+            title=f"No data for {asset_symbol} @ {INTERVAL_LABELS.get(interval, interval)}",
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",
         )
@@ -526,13 +647,16 @@ def build_price_chart(range_value):
     original_count = len(df)
     df = _downsample_ohlcv(df, MAX_CANDLES_DISPLAY)
 
+    symbol_label = f"{asset_symbol}/USDT" if asset_class == "crypto" else asset_symbol
+    interval_label = INTERVAL_LABELS.get(interval, interval)
+
     fig = make_subplots(
         rows=2, cols=1,
         shared_xaxes=True,
         vertical_spacing=0.03,
         row_heights=[0.7, 0.3],
         subplot_titles=(
-            f"BTC/USDT — 1H Candlesticks ({len(df)} candles, from {original_count} raw)",
+            f"{symbol_label} - {interval_label} ({len(df)} candles, from {original_count} raw)",
             "Volume",
         ),
     )
@@ -544,7 +668,7 @@ def build_price_chart(range_value):
             high=df["high"],
             low=df["low"],
             close=df["close"],
-            name="BTC/USDT",
+            name=symbol_label,
             increasing_line_color="#26a69a",
             decreasing_line_color="#ef5350",
         ),
@@ -575,13 +699,13 @@ def build_price_chart(range_value):
         xaxis=dict(
             rangeselector=dict(
                 buttons=list([
-                    dict(count=1, label="1d", step="day", stepmode="backward"),
-                    dict(count=3, label="3d", step="day", stepmode="backward"),
-                    dict(count=7, label="1w", step="day", stepmode="backward"),
-                    dict(count=1, label="1m", step="month", stepmode="backward"),
-                    dict(count=3, label="3m", step="month", stepmode="backward"),
-                    dict(count=6, label="6m", step="month", stepmode="backward"),
-                    dict(count=1, label="1y", step="year", stepmode="backward"),
+                    dict(count=1, label="1D", step="day", stepmode="backward"),
+                    dict(count=3, label="3D", step="day", stepmode="backward"),
+                    dict(count=7, label="1W", step="day", stepmode="backward"),
+                    dict(count=1, label="1M", step="month", stepmode="backward"),
+                    dict(count=3, label="3M", step="month", stepmode="backward"),
+                    dict(count=6, label="6M", step="month", stepmode="backward"),
+                    dict(count=1, label="1Y", step="year", stepmode="backward"),
                     dict(step="all", label="All"),
                 ]),
                 bgcolor="#2a2a2a",

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -13,3 +13,35 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DB_PATH = os.path.join("database", "financial_data.duckdb")
+
+app = dash.Dash(
+    __name__,
+    external_stylesheets=[dbc.themes.DARKLY],
+    suppress_callback_exceptions=True,
+    title="Financial Data Analyzer",
+)
+
+app.layout = dbc.Container(
+    fluid=True,
+    className="p-3",
+    children=[
+        dbc.Row(
+            dbc.Col(
+                html.H1(" Financial Data Analyzer", className="text-center text-info my-3"),
+                width=12,
+            )
+        ),
+        dbc.Tabs(
+            id="main-tabs",
+            active_tab="tab-price",
+            children=[
+                dbc.Tab(label=" Price Dashboard", tab_id="tab-price"),
+                dbc.Tab(label=" Predictions", tab_id="tab-predictions"),
+                dbc.Tab(label=" Technical Indicators", tab_id="tab-indicators"),
+                dbc.Tab(label=" Data Explorer", tab_id="tab-explorer"),
+            ],
+        ),
+        html.Hr(),
+        html.Div(id="tab-content"),
+    ],
+)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -334,17 +334,70 @@ def render_predictions():
         return dbc.Alert(f"Error loading predictions: {e}", color="danger")
 
 def render_indicators():
-    return dbc.Row(
-        dbc.Col(
-            html.Div(
-                [
-                    html.H3("Technical Indicators", className="text-light"),
-                    html.P("RSI, MACD, Bollinger Bands, and SMA crossovers.", className="text-muted"),
-                ]
-            ),
-            width=12,
+    """RSI, MACD, Bollinger Bands, and SMA crossover charts from gold_crypto_features."""
+    try:
+        conn = duckdb.connect(DB_PATH, read_only=True)
+        df = conn.execute("""
+            SELECT date, close, rsi_14, macd, macd_signal, macd_histogram,
+                   bb_upper, bb_middle, bb_lower,
+                   sma_7, sma_30, sma_50, sma_200, volume_ratio
+            FROM gold_crypto_features
+            WHERE asset_symbol = 'BTC' AND interval = '1h'
+            ORDER BY date
+        """).df()
+        conn.close()
+        if df.empty:
+            return dbc.Alert("No technical indicator data available. Run the pipeline first.", color="warning")
+        df["date"] = pd.to_datetime(df["date"])
+
+        fig = make_subplots(
+            rows=4, cols=1,
+            shared_xaxes=True,
+            vertical_spacing=0.03,
+            row_heights=[0.35, 0.20, 0.25, 0.20],
+            subplot_titles=("Price + Bollinger Bands (20,2)", "RSI (14)", "MACD (12,26,9)", "SMA Crossover (7/30/50/200)"),
         )
-    )
+
+        fig.add_trace(go.Scatter(x=df["date"], y=df["close"], name="Close", line=dict(color="#17BECF", width=1.5)), row=1, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["bb_upper"], name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8)), row=1, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["bb_middle"], name="BB Middle", line=dict(color="rgba(255,255,255,0.35)", width=0.8, dash="dot")), row=1, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["bb_lower"], name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.05)"), row=1, col=1)
+
+        fig.add_trace(go.Scatter(x=df["date"], y=df["rsi_14"], name="RSI (14)", line=dict(color="#F39C12", width=1.2)), row=2, col=1)
+        fig.add_hline(y=70, line_dash="dash", line_color="rgba(255,80,80,0.5)", row=2, col=1)
+        fig.add_hline(y=30, line_dash="dash", line_color="rgba(80,255,80,0.5)", row=2, col=1)
+        fig.add_hrect(y0=70, y1=100, fillcolor="rgba(255,0,0,0.06)", line_width=0, row=2, col=1)
+        fig.add_hrect(y0=0, y1=30, fillcolor="rgba(0,255,0,0.06)", line_width=0, row=2, col=1)
+
+        colors_macd = ["#2ECC40" if v >= 0 else "#FF4136" for v in df["macd_histogram"]]
+        fig.add_trace(go.Bar(x=df["date"], y=df["macd_histogram"], name="Histogram", marker_color=colors_macd, marker_line_width=0), row=3, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["macd"], name="MACD", line=dict(color="#3498DB", width=1.2)), row=3, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["macd_signal"], name="Signal", line=dict(color="#E74C3C", width=1.0)), row=3, col=1)
+
+        fig.add_trace(go.Scatter(x=df["date"], y=df["close"], name="Close", line=dict(color="rgba(255,255,255,0.3)", width=0.8)), row=4, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["sma_7"], name="SMA 7", line=dict(color="#1ABC9C", width=1.2)), row=4, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["sma_30"], name="SMA 30", line=dict(color="#9B59B6", width=1.2)), row=4, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["sma_50"], name="SMA 50", line=dict(color="#E67E22", width=1.0, dash="dot"),), row=4, col=1)
+        fig.add_trace(go.Scatter(x=df["date"], y=df["sma_200"], name="SMA 200", line=dict(color="#E74C3C", width=1.2, dash="dot"),), row=4, col=1)
+
+        fig.update_xaxes(showgrid=True, gridcolor="rgba(255,255,255,0.05)", showline=True, linecolor="rgba(255,255,255,0.15)", row=4, col=1)
+        fig.update_yaxes(showgrid=True, gridcolor="rgba(255,255,255,0.05)", showline=True, linecolor="rgba(255,255,255,0.15)", zeroline=True, zerolinecolor="rgba(255,255,255,0.15)")
+        fig.update_layout(
+            template="plotly_dark",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=900,
+            hovermode="x unified",
+            margin=dict(l=10, r=10, t=50, b=10),
+            showlegend=False,
+        )
+
+        return html.Div([
+            html.H3("BTC/USDT 1H - Technical Indicators", className="text-light mb-3"),
+            dbc.Row(dbc.Col(dcc.Graph(figure=fig, config={"displayModeBar": True, "responsive": True}), width=12)),
+        ])
+    except Exception as e:
+        return dbc.Alert(f"Error loading indicators: {e}", color="danger")
 
 def render_explorer():
     return dbc.Row(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -45,3 +45,19 @@ app.layout = dbc.Container(
         html.Div(id="tab-content"),
     ],
 )
+
+@app.callback(
+    dash.Output("tab-content", "children"),
+    dash.Input("main-tabs", "active_tab"),
+)
+def render_tab(active_tab: str):
+    """Route to the correct tab layout based on the active tab ID."""
+    if active_tab == "tab-price":
+        return render_price_dashboard()
+    elif active_tab == "tab-predictions":
+        return render_predictions()
+    elif active_tab == "tab-indicators":
+        return render_indicators()
+    elif active_tab == "tab-explorer":
+        return render_explorer()
+    return html.P("Select a tab.", className="text-muted")

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -4,7 +4,7 @@ Multi-tab web UI reading directly from DuckDB gold tables.
 """
 
 import dash
-from dash import dcc, html
+from dash import dcc, html, dash_table
 import dash_bootstrap_components as dbc
 import duckdb
 import pandas as pd
@@ -400,17 +400,85 @@ def render_indicators():
         return dbc.Alert(f"Error loading indicators: {e}", color="danger")
 
 def render_explorer():
-    return dbc.Row(
-        dbc.Col(
-            html.Div(
-                [
-                    html.H3("Data Explorer", className="text-light"),
-                    html.P("Sortable tables from gold_crypto_analytics, gold_crypto_features, gold_crypto_predictions, and gold_stock_analytics.", className="text-muted"),
-                ]
+    """Dropdown-driven sortable data table explorer for all gold layer tables."""
+    TABLE_OPTIONS = [
+        {"label": "Crypto Analytics (gold_crypto_analytics)", "value": "gold_crypto_analytics"},
+        {"label": "Crypto Features (gold_crypto_features)", "value": "gold_crypto_features"},
+        {"label": "Crypto Predictions (gold_crypto_predictions)", "value": "gold_crypto_predictions"},
+        {"label": "Stock Analytics (gold_stock_analytics)", "value": "gold_stock_analytics"},
+        {"label": "Stock Features (gold_stock_features)", "value": "gold_stock_features"},
+    ]
+    return html.Div([
+        html.H3("Data Explorer", className="text-light mb-3"),
+        dbc.Row([
+            dbc.Col(
+                dcc.Dropdown(
+                    id="explorer-table-selector",
+                    options=TABLE_OPTIONS,
+                    value="gold_crypto_analytics",
+                    clearable=False,
+                    className="mb-3",
+                    style={"backgroundColor": "#303030", "color": "#212529"},
+                ),
+                width=6,
             ),
-            width=12,
+            dbc.Col(html.Div(id="explorer-row-count", className="text-muted mt-2"), width=6),
+        ]),
+        dbc.Row(dbc.Col(html.Div(id="explorer-table-container"), width=12)),
+    ])
+
+
+@app.callback(
+    dash.Output("explorer-table-container", "children"),
+    dash.Output("explorer-row-count", "children"),
+    dash.Input("explorer-table-selector", "value"),
+)
+def update_explorer_table(table_name):
+    """Query the selected gold table and render a sortable DataTable."""
+    try:
+        conn = duckdb.connect(DB_PATH, read_only=True)
+        df = conn.execute(f"SELECT * FROM {table_name} ORDER BY date DESC LIMIT 5000").df()
+        conn.close()
+        if df.empty:
+            return dbc.Alert(f"Table '{table_name}' is empty. Run the pipeline first.", color="warning"), ""
+        df["date"] = pd.to_datetime(df["date"]).dt.strftime("%Y-%m-%d %H:%M")
+        total = len(df)
+        row_text = f"Showing {total} row{'s' if total != 1 else ''} (latest 5,000)"
+        columns = [{"name": col, "id": col} for col in df.columns]
+        table = dash_table.DataTable(
+            data=df.to_dict("records"),
+            columns=columns,
+            page_size=25,
+            sort_action="native",
+            filter_action="native",
+            style_table={"overflowX": "auto"},
+            style_cell={
+                "backgroundColor": "#222222",
+                "color": "#e0e0e0",
+                "borderColor": "#404040",
+                "fontSize": "12px",
+                "padding": "4px 8px",
+                "minWidth": "80px",
+            },
+            style_header={
+                "backgroundColor": "#333333",
+                "fontWeight": "bold",
+                "borderColor": "#555555",
+            },
+            style_filter={
+                "backgroundColor": "#2a2a2a",
+                "borderColor": "#555555",
+            },
+            style_data_conditional=[
+                {
+                    "if": {"row_index": "odd"},
+                    "backgroundColor": "#262626",
+                },
+            ],
         )
-    )
+        return table, row_text
+    except Exception as e:
+        return dbc.Alert(f"Error loading table '{table_name}': {e}", color="danger"), ""
     
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0", port=8050)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -12,6 +12,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import os
 from dotenv import load_dotenv
+from dashboard.predictor import run_prediction
 
 load_dotenv()
 
@@ -143,17 +144,194 @@ def render_price_dashboard():
         return dbc.Alert(f"Error loading price dashboard: {e}", color="danger")
 
 def render_predictions():
-    return dbc.Row(
-        dbc.Col(
-            html.Div(
-                [
-                    html.H3("Model Predictions — Actual vs Predicted", className="text-light"),
-                    html.P("Accuracy gauge, confusion matrix, and prediction overlay charts.", className="text-muted"),
-                ]
-            ),
-            width=12,
+    """XGBoost model predictions: actual vs predicted direction chart, accuracy, and confidence distribution."""
+    try:
+        results = run_prediction(asset="BTC", interval="1h")
+
+        if results is None or results.empty:
+            return dbc.Alert("No prediction data available. Run the full pipeline first to populate gold_crypto_features.", color="warning")
+
+        total = len(results)
+        correct = (results["prediction"] == results["actual_direction"]).sum()
+        accuracy = correct / total if total > 0 else 0
+        up_pred_pct = (results["prediction"] == 1).sum() / total * 100
+
+        summary_cards = dbc.Row(
+            [
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody([
+                            html.H5(f"{total:,}", className="card-title text-info"),
+                            html.P("Total Predictions", className="card-text text-muted small"),
+                        ]),
+                        color="dark", outline=True,
+                    ),
+                    width=3,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody([
+                            html.H5(f"{accuracy:.1%}", className="card-title text-info"),
+                            html.P("Accuracy (52.6% baseline)", className="card-text text-muted small"),
+                        ]),
+                        color="dark", outline=True,
+                    ),
+                    width=3,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody([
+                            html.H5(f"{up_pred_pct:.1f}%", className="card-title text-info"),
+                            html.P("UP Predictions", className="card-text text-muted small"),
+                        ]),
+                        color="dark", outline=True,
+                    ),
+                    width=3,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody([
+                            html.H5(f"{correct:,}", className="card-title text-info"),
+                            html.P("Correct Predictions", className="card-text text-muted small"),
+                        ]),
+                        color="dark", outline=True,
+                    ),
+                    width=3,
+                ),
+            ],
+            className="mb-3",
         )
-    )
+
+        fig_overlay = make_subplots(
+            rows=2, cols=1,
+            shared_xaxes=True,
+            vertical_spacing=0.05,
+            row_heights=[0.7, 0.3],
+            subplot_titles=("Close Price with Prediction Markers", "Confidence Over Time"),
+        )
+
+        fig_overlay.add_trace(
+            go.Scatter(
+                x=results["date"], y=results["close"],
+                mode="lines", name="Close Price",
+                line=dict(color="#17a2b8", width=1),
+            ),
+            row=1, col=1,
+        )
+
+        correct_mask = results["prediction"] == results["actual_direction"]
+        wrong_mask = ~correct_mask
+
+        for mask, color, label in [
+            (correct_mask, "#26a69a", "Correct"),
+            (wrong_mask, "#ef5350", "Wrong"),
+        ]:
+            subset = results[mask]
+            if not subset.empty:
+                fig_overlay.add_trace(
+                    go.Scatter(
+                        x=subset["date"], y=subset["close"],
+                        mode="markers", name=label,
+                        marker=dict(color=color, size=5, symbol="circle"),
+                    ),
+                    row=1, col=1,
+                )
+
+        fig_overlay.add_trace(
+            go.Scatter(
+                x=results["date"], y=results["confidence"],
+                mode="lines", name="Confidence",
+                line=dict(color="#ffc107", width=1),
+                fill="tozeroy", fillcolor="rgba(255,193,7,0.1)",
+            ),
+            row=2, col=1,
+        )
+
+        fig_overlay.update_layout(
+            template="plotly_dark",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=650,
+            hovermode="x unified",
+            showlegend=True,
+            legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+            margin=dict(l=10, r=10, t=40, b=10),
+        )
+        fig_overlay.update_yaxes(title_text="Price (USD)", row=1, col=1)
+        fig_overlay.update_yaxes(title_text="Confidence", row=2, col=1)
+
+        fig_hist = go.Figure()
+        fig_hist.add_trace(
+            go.Histogram(
+                x=results["confidence"], nbinsx=40,
+                marker_color="#17a2b8", opacity=0.8,
+                name="Confidence",
+            )
+        )
+        fig_hist.add_vline(
+            x=0.5, line_dash="dash", line_color="#ef5350",
+            annotation_text="Random (0.5)", annotation_position="top left",
+        )
+        fig_hist.update_layout(
+            template="plotly_dark",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=350,
+            title="Confidence Distribution",
+            xaxis_title="Prediction Confidence",
+            yaxis_title="Count",
+            margin=dict(l=10, r=10, t=40, b=10),
+        )
+
+        fig_gauge = go.Figure(
+            go.Indicator(
+                mode="gauge+number",
+                value=accuracy * 100,
+                number={"suffix": "%", "font": {"size": 48, "color": "#17a2b8"}},
+                title={"text": "Model Accuracy", "font": {"size": 14}},
+                gauge={
+                    "axis": {"range": [0, 100], "tickcolor": "#adb5bd"},
+                    "bar": {"color": "#26a69a" if accuracy >= 0.5 else "#ef5350"},
+                    "steps": [
+                        {"range": [0, 50], "color": "rgba(239,83,80,0.3)"},
+                        {"range": [50, 52], "color": "rgba(255,193,7,0.3)"},
+                        {"range": [52, 60], "color": "rgba(38,166,154,0.3)"},
+                        {"range": [60, 100], "color": "rgba(38,166,154,0.5)"},
+                    ],
+                    "threshold": {
+                        "line": {"color": "white", "width": 2},
+                        "value": 52.6,
+                    },
+                },
+            )
+        )
+        fig_gauge.update_layout(
+            template="plotly_dark",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=350,
+            margin=dict(l=10, r=10, t=40, b=10),
+        )
+
+        return html.Div([
+            html.H3("BTC/USDT 1H -- XGBoost Direction Predictions", className="text-light mb-3"),
+            summary_cards,
+            dbc.Row(
+                [
+                    dbc.Col(dcc.Graph(figure=fig_gauge, config={"responsive": True}), width=4),
+                    dbc.Col(dcc.Graph(figure=fig_hist, config={"responsive": True}), width=8),
+                ],
+                className="mb-3",
+            ),
+            dbc.Row(
+                dbc.Col(
+                    dcc.Graph(figure=fig_overlay, config={"displayModeBar": True, "responsive": True}),
+                    width=12,
+                )
+            ),
+        ])
+    except Exception as e:
+        return dbc.Alert(f"Error loading predictions: {e}", color="danger")
 
 def render_indicators():
     return dbc.Row(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -3,6 +3,11 @@ Financial Data Analyzer — Plotly Dash Dashboard
 Multi-tab web UI reading directly from DuckDB gold tables.
 """
 
+import os
+import sys
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
 import dash
 from dash import dcc, html, dash_table
 import dash_bootstrap_components as dbc
@@ -10,12 +15,10 @@ import duckdb
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-import os
 from dotenv import load_dotenv
 from dashboard.predictor import run_prediction
 
 load_dotenv()
-
 DB_PATH = os.path.join("database", "financial_data.duckdb")
 
 app = dash.Dash(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -7,6 +7,9 @@ import dash
 from dash import dcc, html
 import dash_bootstrap_components as dbc
 import duckdb
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import os
 from dotenv import load_dotenv
 
@@ -64,17 +67,80 @@ def render_tab(active_tab: str):
     return html.P("Select a tab.", className="text-muted")
 
 def render_price_dashboard():
-    return dbc.Row(
-        dbc.Col(
-            html.Div(
-                [
-                    html.H3("BTC/USDT — Price History", className="text-light"),
-                    html.P("Candlestick chart and volume bars.", className="text-muted"),
-                ]
-            ),
-            width=12,
+    """BTC/USDT candlestick chart + volume bars from gold_crypto_analytics."""
+    try:
+        conn = duckdb.connect(DB_PATH, read_only=True)
+        df = conn.execute("""
+            SELECT date, open, high, low, close, volume
+            FROM gold_crypto_analytics
+            WHERE asset_symbol = 'BTC' AND interval = '1h'
+            ORDER BY date
+        """).df()
+        conn.close()
+
+        if df.empty:
+            return dbc.Alert("No data found in gold_crypto_analytics for BTC 1h.", color="warning")
+
+        df["date"] = pd.to_datetime(df["date"])
+
+        fig = make_subplots(
+            rows=2, cols=1,
+            shared_xaxes=True,
+            vertical_spacing=0.03,
+            row_heights=[0.7, 0.3],
+            subplot_titles=("BTC/USDT — 1H Candlesticks", "Volume"),
         )
-    )
+
+        fig.add_trace(
+            go.Candlestick(
+                x=df["date"],
+                open=df["open"],
+                high=df["high"],
+                low=df["low"],
+                close=df["close"],
+                name="BTC/USDT",
+                increasing_line_color="#26a69a",
+                decreasing_line_color="#ef5350",
+            ),
+            row=1, col=1,
+        )
+
+        colors = ["#26a69a" if c >= o else "#ef5350" for o, c in zip(df["open"], df["close"])]
+        fig.add_trace(
+            go.Bar(
+                x=df["date"],
+                y=df["volume"],
+                name="Volume",
+                marker_color=colors,
+                opacity=0.6,
+            ),
+            row=2, col=1,
+        )
+
+        fig.update_layout(
+            template="plotly_dark",
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=700,
+            hovermode="x unified",
+            showlegend=False,
+            margin=dict(l=10, r=10, t=40, b=10),
+            xaxis_rangeslider_visible=False,
+        )
+        fig.update_yaxes(title_text="Price (USD)", row=1, col=1)
+        fig.update_yaxes(title_text="Volume", row=2, col=1)
+
+        return dbc.Row(
+            dbc.Col(
+                [
+                    html.H3(" BTC/USDT — Price History", className="text-light mb-3"),
+                    dcc.Graph(figure=fig, config={"displayModeBar": True, "responsive": True}),
+                ],
+                width=12,
+            )
+        )
+    except Exception as e:
+        return dbc.Alert(f"Error loading price dashboard: {e}", color="danger")
 
 def render_predictions():
     return dbc.Row(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -50,6 +50,7 @@ app.layout = dbc.Container(
     dash.Output("tab-content", "children"),
     dash.Input("main-tabs", "active_tab"),
 )
+
 def render_tab(active_tab: str):
     """Route to the correct tab layout based on the active tab ID."""
     if active_tab == "tab-price":
@@ -61,3 +62,55 @@ def render_tab(active_tab: str):
     elif active_tab == "tab-explorer":
         return render_explorer()
     return html.P("Select a tab.", className="text-muted")
+
+def render_price_dashboard():
+    return dbc.Row(
+        dbc.Col(
+            html.Div(
+                [
+                    html.H3("BTC/USDT — Price History", className="text-light"),
+                    html.P("Candlestick chart and volume bars.", className="text-muted"),
+                ]
+            ),
+            width=12,
+        )
+    )
+
+def render_predictions():
+    return dbc.Row(
+        dbc.Col(
+            html.Div(
+                [
+                    html.H3("Model Predictions — Actual vs Predicted", className="text-light"),
+                    html.P("Accuracy gauge, confusion matrix, and prediction overlay charts.", className="text-muted"),
+                ]
+            ),
+            width=12,
+        )
+    )
+
+def render_indicators():
+    return dbc.Row(
+        dbc.Col(
+            html.Div(
+                [
+                    html.H3("Technical Indicators", className="text-light"),
+                    html.P("RSI, MACD, Bollinger Bands, and SMA crossovers.", className="text-muted"),
+                ]
+            ),
+            width=12,
+        )
+    )
+
+def render_explorer():
+    return dbc.Row(
+        dbc.Col(
+            html.Div(
+                [
+                    html.H3("Data Explorer", className="text-light"),
+                    html.P("Sortable tables from gold_crypto_analytics, gold_crypto_features, gold_crypto_predictions, and gold_stock_analytics.", className="text-muted"),
+                ]
+            ),
+            width=12,
+        )
+    )

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -114,3 +114,6 @@ def render_explorer():
             width=12,
         )
     )
+    
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=8050)

--- a/dashboard/predictor.py
+++ b/dashboard/predictor.py
@@ -65,11 +65,15 @@ def _make_stationary(df):
     return df
 
 
-def load_model():
-    """Load the trained XGBoost classifier from disk."""
-    model = xgb.XGBClassifier()
-    model.load_model(MODEL_PATH)
-    return model
+_model_cache = None
+def _get_model():
+    """Return the cached XGBoost model, loading it once on first call."""
+    global _model_cache
+    if _model_cache is None:
+        model = xgb.XGBClassifier()
+        model.load_model(MODEL_PATH)
+        _model_cache = model
+    return _model_cache
 
 
 def run_prediction(asset="BTC", interval="1h"):
@@ -80,9 +84,21 @@ def run_prediction(asset="BTC", interval="1h"):
     or None if no data is available.
     """
     conn = duckdb.connect(DB_PATH, read_only=True)
+    needed_cols = [
+        "date", "close",
+        "sma_7", "sma_30", "sma_50", "sma_100", "sma_200",
+        "ema_12", "ema_26", "ema_50", "ema_200",
+        "vwap", "macd", "macd_signal", "macd_histogram",
+        "atr_14", "daily_volatility",
+        "rsi_14", "roc_10", "roc_20", "stoch_k", "stoch_d",
+        "bb_percentage", "volume_ratio",
+        "returns_1p", "returns_5p", "returns_10p", "returns_20p",
+        "log_returns", "hl_ratio", "close_position",
+    ]
+    col_list = ", ".join(needed_cols)
 
     df = conn.execute(f"""
-        SELECT *
+        SELECT {col_list}
         FROM gold_crypto_features
         WHERE asset_symbol = '{asset}' AND interval = '{interval}'
         ORDER BY date
@@ -107,7 +123,7 @@ def run_prediction(asset="BTC", interval="1h"):
     if df_clean.empty:
         return None
 
-    model = load_model()
+    model = _get_model()
     X = df_clean[available_features]
     predictions = model.predict(X)
     probabilities = model.predict_proba(X)

--- a/dashboard/predictor.py
+++ b/dashboard/predictor.py
@@ -1,0 +1,128 @@
+"""
+Prediction inference module for the Dash dashboard.
+Loads the trained XGBoost model, queries gold_crypto_features,
+applies stationarity transformations, and runs inference.
+"""
+
+import os
+import numpy as np
+import pandas as pd
+import duckdb
+import xgboost as xgb
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_PATH = os.path.join("database", "financial_data.duckdb")
+MODEL_PATH = os.path.join("src", "models", "BTC_1h_xgboost_model.json")
+
+MODEL_FEATURES = [
+    "rsi_14", "roc_10", "roc_20", "stoch_k", "stoch_d", "bb_percentage",
+    "volume_ratio", "returns_1p", "returns_5p", "returns_10p", "returns_20p",
+    "log_returns", "hl_ratio", "close_position",
+    "sma_7_dist", "sma_30_dist", "sma_50_dist", "sma_100_dist", "sma_200_dist",
+    "ema_12_dist", "ema_26_dist", "ema_50_dist", "ema_200_dist", "vwap_dist",
+    "macd_pct", "macd_sig_pct", "macd_hist_pct", "atr_pct", "volatility_pct",
+]
+
+
+def _make_stationary(df):
+    """Convert raw technical indicators to stationary features expected by the model.
+
+    The XGBoost model was trained on stationary distance/ratio features to avoid
+    memorizing absolute price levels. Raw indicators (sma_7, ema_12, macd, atr_14, etc.)
+    are transformed into relative measures (distance from close or percentage of close).
+    """
+    df = df.copy()
+    c = df["close"].replace(0, np.nan)
+
+    for window in [7, 30, 50, 100, 200]:
+        col = f"sma_{window}"
+        if col in df.columns:
+            df[f"sma_{window}_dist"] = (df["close"] / df[col]) - 1
+
+    for window in [12, 26, 50, 200]:
+        col = f"ema_{window}"
+        if col in df.columns:
+            df[f"ema_{window}_dist"] = (df["close"] / df[col]) - 1
+
+    if "vwap" in df.columns:
+        df["vwap_dist"] = (df["close"] / df["vwap"]) - 1
+
+    if "macd" in df.columns:
+        df["macd_pct"] = df["macd"] / c
+    if "macd_signal" in df.columns:
+        df["macd_sig_pct"] = df["macd_signal"] / c
+    if "macd_histogram" in df.columns:
+        df["macd_hist_pct"] = df["macd_histogram"] / c
+
+    if "atr_14" in df.columns:
+        df["atr_pct"] = df["atr_14"] / c
+
+    if "daily_volatility" in df.columns:
+        df["volatility_pct"] = df["daily_volatility"] / c
+
+    return df
+
+
+def load_model():
+    """Load the trained XGBoost classifier from disk."""
+    model = xgb.XGBClassifier()
+    model.load_model(MODEL_PATH)
+    return model
+
+
+def run_prediction(asset="BTC", interval="1h"):
+    """Run the full prediction pipeline for a given asset and interval.
+
+    Returns a DataFrame with columns:
+        date, close, prediction, confidence, actual_direction
+    or None if no data is available.
+    """
+    conn = duckdb.connect(DB_PATH, read_only=True)
+
+    df = conn.execute(f"""
+        SELECT *
+        FROM gold_crypto_features
+        WHERE asset_symbol = '{asset}' AND interval = '{interval}'
+        ORDER BY date
+    """).df()
+
+    conn.close()
+
+    if df.empty:
+        return None
+
+    df["date"] = pd.to_datetime(df["date"])
+
+    df = _make_stationary(df)
+
+    available_features = [f for f in MODEL_FEATURES if f in df.columns]
+    if len(available_features) < len(MODEL_FEATURES):
+        missing = set(MODEL_FEATURES) - set(available_features)
+        print(f"Warning: missing features for prediction: {missing}")
+
+    df_clean = df.dropna(subset=available_features)
+
+    if df_clean.empty:
+        return None
+
+    model = load_model()
+    X = df_clean[available_features]
+    predictions = model.predict(X)
+    probabilities = model.predict_proba(X)
+
+    up_prob = probabilities[:, 1]
+
+    results = df_clean[["date", "close"]].copy()
+    results["prediction"] = predictions
+    results["confidence"] = np.where(predictions == 1, up_prob, 1 - up_prob)
+
+    results["actual_direction"] = (
+        results["close"].shift(-1) > results["close"]
+    ).astype(int)
+
+    results = results.dropna(subset=["actual_direction"])
+    results["actual_direction"] = results["actual_direction"].astype(int)
+
+    return results

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,24 @@ services:
     networks:
       - custom_net
 
+  dashboard:
+    build: .
+    container_name: financial_data_dashboard
+    env_file:
+      - .env
+    ports:
+      - "8050:8050"
+    volumes:
+      - ./database:/app/database
+      - .:/app
+    restart: unless-stopped
+    depends_on:
+      pipeline:
+        condition: service_started
+    networks:
+      - custom_net
+    command: python dashboard/app.py
+
 volumes:
   minio_data:
   superset_home:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ ta>=0.11.0
 scikit-learn>=1.3.0
 tabulate>=0.9.0
 xgboost>=2.0.0
+dash>=2.14.0
+dash-bootstrap-components>=1.5.0
+plotly>=5.18.0


### PR DESCRIPTION
Built a Plotly Dash web dashboard with 4 tabs: Price Dashboard, Predictions, Technical Indicators, and Data Explorer. Reads directly from DuckDB gold tables.

Price Dashboard: Multi-asset candlestick charts with asset class (Crypto/Stocks), asset, interval, and time-range dropdowns. OHLCV downsampling (max 2000 candles) + rangeslider + zoom presets for instant rendering. Supports all 11 crypto + 6 stock assets across all their intervals.

Predictions: XGBoost direction predictions with accuracy gauge, confidence histogram, and price overlay with correct/wrong markers. Model caching for performance.

Technical Indicators: RSI, MACD, Bollinger Bands, SMA crossover subplots (currently BTC/1h).

Data Explorer: Sortable/filterable table for any gold layer table.

Performance fixes: Model caching, narrow SQL SELECTs, candle downsampling, time-range defaults, DuckDB read-only connections.

Added dashboard service to docker-compose.yaml (port 8050).

On Next issue: To Add asset/interval dropdowns to Predictions and Technical Indicators tabs (currently hardcoded BTC/1h). Add time-range filtering to Technical Indicators for performance. Improve indicator chart clarity and hovermode consistency.

- Close #103 