### PR TITLE
113 toggleable indicator overlays on candlestick chart

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -163,6 +163,21 @@ def render_price_dashboard():
                         ],
                         className="mb-3",
                     ),
+                    dbc.Checklist(
+                        id="indicator-toggles",
+                        options=[
+                            {"label": "EMA 9", "value": "ema9"},
+                            {"label": "EMA 21", "value": "ema21"},
+                            {"label": "EMA 50", "value": "ema50"},
+                            {"label": "SMA 50", "value": "sma50"},
+                            {"label": "SMA 200", "value": "sma200"},
+                            {"label": "Bollinger Bands", "value": "bb"},
+                            {"label": "VWAP", "value": "vwap"},
+                        ],
+                        value=[],
+                        inline=True,
+                        className="mb-3",
+                    ),
                     dcc.Loading(
                         id="loading-price",
                         type="circle",
@@ -527,8 +542,9 @@ def update_interval_dropdown(asset_class):
     dash.Input("price-asset-dropdown", "value"),
     dash.Input("price-interval-dropdown", "value"),
     dash.Input("price-range-dropdown", "value"),
+    dash.Input("indicator-toggles", "value"),
 )
-def build_price_chart(asset_class, asset_symbol, interval, range_value):
+def build_price_chart(asset_class, asset_symbol, interval, range_value, indicators):
     """Query the database, downsample if needed, and build the OHLCV figure."""
 
     if not asset_symbol or not interval or not asset_class:
@@ -617,13 +633,58 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value):
         row=2, col=1,
     )
 
+    if indicators:
+        INDICATOR_CONFIG = {
+            "ema9":  {"type": "ema", "span": 9,  "name": "EMA 9",  "color": "#2196f3"},
+            "ema21": {"type": "ema", "span": 21, "name": "EMA 21", "color": "#ff9800"},
+            "ema50": {"type": "ema", "span": 50, "name": "EMA 50", "color": "#9c27b0"},
+            "sma50": {"type": "sma", "span": 50, "name": "SMA 50", "color": "#ffeb3b"},
+            "sma200":{"type": "sma", "span": 200,"name": "SMA 200","color": "#e91e63"},
+        }
+        for key in indicators:
+            cfg = INDICATOR_CONFIG.get(key)
+            if not cfg:
+                continue
+            if cfg["type"] == "ema":
+                series = df["close"].ewm(span=cfg["span"], adjust=False).mean()
+            else:
+                series = df["close"].rolling(window=cfg["span"]).mean()
+            fig.add_trace(
+                go.Scatter(
+                    x=df["date"], y=series,
+                    mode="lines", name=cfg["name"],
+                    line=dict(color=cfg["color"], width=1.2),
+                ),
+                row=1, col=1,
+            )
+
+        if "bb" in indicators:
+            sma20 = df["close"].rolling(window=20).mean()
+            std20 = df["close"].rolling(window=20).std()
+            bb_upper = sma20 + 2 * std20
+            bb_lower = sma20 - 2 * std20
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8)), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash")), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)"), row=1, col=1)
+
+        if "vwap" in indicators:
+            typical = (df["high"] + df["low"] + df["close"]) / 3
+            cvp = (typical * df["volume"]).cumsum()
+            cv = df["volume"].cumsum()
+            vwap = cvp / cv.replace(0, 1)
+            fig.add_trace(
+                go.Scatter(x=df["date"], y=vwap, mode="lines", name="VWAP",
+                           line=dict(color="#ffeb3b", width=1, dash="dot")),
+                row=1, col=1,
+            )
+
     fig.update_layout(
         template="plotly_dark",
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(0,0,0,0)",
         height=800,
         hovermode="x unified",
-        showlegend=False,
+        showlegend=bool(indicators),
         margin=dict(l=15, r=15, t=45, b=10),
         xaxis_rangeslider_visible=False,
         xaxis=dict(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -633,6 +633,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name=symbol_label,
             increasing_line_color="#26a69a",
             decreasing_line_color="#ef5350",
+            customdata=df[["volume"]].values,
             hovertemplate="<extra></extra>",
         ),
         row=1, col=1,
@@ -646,7 +647,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name="Volume",
             marker_color=colors,
             opacity=0.6,
-            hoverinfo="skip",
+            hovertemplate="<extra></extra>",
         ),
         row=2, col=1,
     )
@@ -672,7 +673,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
                     x=df["date"], y=series,
                     mode="lines", name=cfg["name"],
                     line=dict(color=cfg["color"], width=1.2),
-                    hoverinfo="skip",
+                    hovertemplate="<extra></extra>",
                 ),
                 row=1, col=1,
             )
@@ -682,9 +683,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             std20 = df["close"].rolling(window=20).std()
             bb_upper = sma20 + 2 * std20
             bb_lower = sma20 - 2 * std20
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8), hoverinfo="skip"), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash"), hoverinfo="skip"), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)", hoverinfo="skip"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8), hovertemplate="<extra></extra>"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash"), hovertemplate="<extra></extra>"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)", hovertemplate="<extra></extra>"), row=1, col=1)
 
         if "vwap" in indicators:
             typical = (df["high"] + df["low"] + df["close"]) / 3
@@ -694,7 +695,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             fig.add_trace(
                 go.Scatter(x=df["date"], y=vwap, mode="lines", name="VWAP",
                            line=dict(color="#ffeb3b", width=1, dash="dot"),
-                           hoverinfo="skip"),
+                           hovertemplate="<extra></extra>"),
                 row=1, col=1,
             )
 
@@ -770,17 +771,21 @@ def update_chart_info_bar(hover_data):
     """TradingView-style info bar: OHLCV + indicator values pinned above chart."""
     if not hover_data or not hover_data.get("points"):
         return dash.no_update
-    ohlc_vals = {}
-    ind_vals = {}
+    o = h = l = c = v = None
+    extra = {}
     for pt in hover_data["points"]:
         if "open" in pt:
-            ohlc_vals = {"O": pt["open"], "H": pt["high"], "L": pt["low"], "C": pt["close"]}
-        elif pt.get("y") is not None and pt.get("curveNumber", 0) > 1:
-            ind_vals[pt.get("name", "?")] = pt["y"]
+            o, h, l, c = pt["open"], pt["high"], pt["low"], pt["close"]
+            cd = pt.get("customdata")
+            if cd and len(cd) > 0:
+                v = cd[0]
+        elif pt.get("y") is not None and pt.get("name"):
+            extra[pt["name"]] = pt["y"]
     parts = []
-    if ohlc_vals:
-        parts.append(f"O: {ohlc_vals['O']:.4f}  H: {ohlc_vals['H']:.4f}  L: {ohlc_vals['L']:.4f}  C: {ohlc_vals['C']:.4f}")
-    for name, val in ind_vals.items():
+    if o is not None:
+        vol_txt = f"  V: {v:,.0f}" if v is not None else ""
+        parts.append(f"O: {o:.4f}  H: {h:.4f}  L: {l:.4f}  C: {c:.4f}{vol_txt}")
+    for name, val in extra.items():
         parts.append(f"{name}: {val:.4f}")
     return "  |  ".join(parts) if parts else ""
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -183,7 +183,7 @@ def render_price_dashboard():
                         type="circle",
                         children=dcc.Graph(
                             id="price-chart",
-                            config={"displayModeBar": True, "responsive": True},
+                            config={"displayModeBar": True, "responsive": True, "scrollZoom": True, "displaylogo": False},
                         ),
                     ),
                 ],
@@ -593,6 +593,16 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     original_count = len(df)
     df = _downsample_ohlcv(df, MAX_CANDLES_DISPLAY)
 
+    max_price = df["close"].max()
+    if max_price < 0.01:
+        price_fmt = ".6f"
+    elif max_price < 1:
+        price_fmt = ".4f"
+    elif max_price < 1000:
+        price_fmt = ".2f"
+    else:
+        price_fmt = ".0f"
+
     symbol_label = f"{asset_symbol}/USDT" if asset_class == "crypto" else asset_symbol
     interval_label = INTERVAL_LABELS.get(interval, interval)
 
@@ -618,7 +628,10 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             increasing_line_color="#26a69a",
             decreasing_line_color="#ef5350",
             hovertemplate=(
-                "O: %{open:.2f}<br>H: %{high:.2f}<br>L: %{low:.2f}<br>C: %{close:.2f}<extra></extra>"
+                f"O: %{{open:{price_fmt}}}<br>"
+                f"H: %{{high:{price_fmt}}}<br>"
+                f"L: %{{low:{price_fmt}}}<br>"
+                f"C: %{{close:{price_fmt}}}<extra></extra>"
             ),
         ),
         row=1, col=1,
@@ -689,6 +702,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(0,0,0,0)",
         height=800,
+        dragmode="pan",
         hovermode="x",
         hoverdistance=20,
         hoverlabel=dict(bgcolor="rgba(33,37,41,0.85)", font_size=11),
@@ -703,7 +717,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             spikesnap="cursor",
             spikethickness=1,
             spikecolor="rgba(255,255,255,0.25)",
-            spikedash="dot",
+            spikedash="dash",
             rangeselector=dict(
                 buttons=list([
                     dict(count=1, label="1D", step="day", stepmode="backward"),
@@ -735,12 +749,13 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     fig.update_yaxes(
         title_text="Price (USD)", row=1, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.06)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dash",
+        tickformat=price_fmt,
     )
     fig.update_yaxes(
         title_text="Volume", row=2, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.04)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dash",
     )
 
     return fig

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -593,15 +593,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     original_count = len(df)
     df = _downsample_ohlcv(df, MAX_CANDLES_DISPLAY)
 
-    max_price = df["close"].max()
-    if max_price < 0.01:
-        price_fmt = ".6f"
-    elif max_price < 1:
-        price_fmt = ".4f"
-    elif max_price < 1000:
-        price_fmt = ".2f"
-    else:
-        price_fmt = ".0f"
+    price_fmt = ".4f"
 
     symbol_label = f"{asset_symbol}/USDT" if asset_class == "crypto" else asset_symbol
     interval_label = INTERVAL_LABELS.get(interval, interval)
@@ -715,9 +707,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             showspikes=True,
             spikemode="across",
             spikesnap="cursor",
-            spikethickness=1,
+            spikethickness=2,
             spikecolor="rgba(255,255,255,0.25)",
-            spikedash="dash",
+            spikedash="dot",
             rangeselector=dict(
                 buttons=list([
                     dict(count=1, label="1D", step="day", stepmode="backward"),
@@ -749,13 +741,13 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     fig.update_yaxes(
         title_text="Price (USD)", row=1, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.06)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dash",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=2, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
         tickformat=price_fmt,
     )
     fig.update_yaxes(
         title_text="Volume", row=2, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.04)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dash",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=2, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
     )
 
     return fig

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -617,6 +617,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name=symbol_label,
             increasing_line_color="#26a69a",
             decreasing_line_color="#ef5350",
+            hovertemplate=(
+                "O: %{open:.2f}<br>H: %{high:.2f}<br>L: %{low:.2f}<br>C: %{close:.2f}<extra></extra>"
+            ),
         ),
         row=1, col=1,
     )
@@ -684,6 +687,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
         plot_bgcolor="rgba(0,0,0,0)",
         height=800,
         hovermode="x unified",
+        hoverlabel=dict(bgcolor="#212529", font_size=12),
         showlegend=bool(indicators),
         margin=dict(l=15, r=15, t=45, b=10),
         xaxis_rangeslider_visible=False,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -632,6 +632,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name="Volume",
             marker_color=colors,
             opacity=0.6,
+            hovertemplate="%{y:,.0f}<extra>Volume</extra>",
         ),
         row=2, col=1,
     )
@@ -657,6 +658,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
                     x=df["date"], y=series,
                     mode="lines", name=cfg["name"],
                     line=dict(color=cfg["color"], width=1.2),
+                    hovertemplate=f"%{{y:.2f}}<extra>{cfg['name']}</extra>",
                 ),
                 row=1, col=1,
             )
@@ -666,9 +668,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             std20 = df["close"].rolling(window=20).std()
             bb_upper = sma20 + 2 * std20
             bb_lower = sma20 - 2 * std20
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8)), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash")), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8), hovertemplate="%{y:.2f}<extra>BB Upper</extra>"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash"), hovertemplate="%{y:.2f}<extra>BB Mid</extra>"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)", hovertemplate="%{y:.2f}<extra>BB Lower</extra>"), row=1, col=1)
 
         if "vwap" in indicators:
             typical = (df["high"] + df["low"] + df["close"]) / 3
@@ -677,7 +679,8 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             vwap = cvp / cv.replace(0, 1)
             fig.add_trace(
                 go.Scatter(x=df["date"], y=vwap, mode="lines", name="VWAP",
-                           line=dict(color="#ffeb3b", width=1, dash="dot")),
+                           line=dict(color="#ffeb3b", width=1, dash="dot"),
+                           hovertemplate="%{y:.2f}<extra>VWAP</extra>"),
                 row=1, col=1,
             )
 
@@ -686,8 +689,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(0,0,0,0)",
         height=800,
-        hovermode="x unified",
-        hoverlabel=dict(bgcolor="#212529", font_size=12),
+        hovermode="x",
+        hoverdistance=20,
+        hoverlabel=dict(bgcolor="rgba(33,37,41,0.85)", font_size=11),
         showlegend=bool(indicators),
         margin=dict(l=15, r=15, t=45, b=10),
         xaxis_rangeslider_visible=False,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -30,6 +30,17 @@ app = dash.Dash(
     title="Financial Data Analyzer",
 )
 
+PRICE_RANGE_OPTIONS = [
+    {"label": "1 Day", "value": "1d"},
+    {"label": "3 Days", "value": "3d"},
+    {"label": "1 Week", "value": "7d"},
+    {"label": "1 Month", "value": "30d"},
+    {"label": "3 Months", "value": "90d"},
+    {"label": "6 Months", "value": "180d"},
+    {"label": "1 Year", "value": "365d"},
+    {"label": "All Data", "value": "all"},
+]
+
 app.layout = dbc.Container(
     fluid=True,
     className="p-3",
@@ -64,6 +75,104 @@ app.layout = dbc.Container(
             ],
         ),
         html.Hr(),
+        dbc.Checklist(
+            id="indicator-toggles",
+            options=[
+                {"label": "EMA 9", "value": "ema9"},
+                {"label": "EMA 21", "value": "ema21"},
+                {"label": "EMA 50", "value": "ema50"},
+                {"label": "SMA 50", "value": "sma50"},
+                {"label": "SMA 200", "value": "sma200"},
+                {"label": "Bollinger Bands", "value": "bb"},
+                {"label": "VWAP", "value": "vwap"},
+            ],
+            value=[],
+            inline=True,
+            className="mb-2",
+        ),
+        html.Div(
+            id="price-chart-area",
+            children=[
+                html.H3("Price Dashboard", className="text-light mb-3"),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            [
+                                html.Label("Asset Class", className="text-muted small mb-1"),
+                                dcc.Dropdown(
+                                    id="price-class-dropdown",
+                                    options=[
+                                        {"label": "Crypto", "value": "crypto"},
+                                        {"label": "Stocks", "value": "stocks"},
+                                    ],
+                                    value="crypto",
+                                    clearable=False,
+                                    searchable=False,
+                                    style={"color": "#000"},
+                                ),
+                            ],
+                            width=2,
+                        ),
+                        dbc.Col(
+                            [
+                                html.Label("Asset", className="text-muted small mb-1"),
+                                dcc.Dropdown(
+                                    id="price-asset-dropdown",
+                                    clearable=False,
+                                    searchable=True,
+                                    style={"color": "#000"},
+                                ),
+                            ],
+                            width=2,
+                        ),
+                        dbc.Col(
+                            [
+                                html.Label("Interval", className="text-muted small mb-1"),
+                                dcc.Dropdown(
+                                    id="price-interval-dropdown",
+                                    clearable=False,
+                                    searchable=False,
+                                    style={"color": "#000"},
+                                ),
+                            ],
+                            width=2,
+                        ),
+                        dbc.Col(
+                            [
+                                html.Label("Time Range", className="text-muted small mb-1"),
+                                dcc.Dropdown(
+                                    id="price-range-dropdown",
+                                    options=PRICE_RANGE_OPTIONS,
+                                    value="7d",
+                                    clearable=False,
+                                    searchable=False,
+                                    style={"color": "#000"},
+                                ),
+                            ],
+                            width=2,
+                        ),
+                    ],
+                    className="mb-3",
+                ),
+                html.Div(
+                    id="chart-info-bar",
+                    style={
+                        "color": "#adb5bd", "fontSize": "12px", "fontFamily": "monospace",
+                        "padding": "2px 8px", "backgroundColor": "rgba(33,37,41,0.6)",
+                        "borderRadius": "4px", "minHeight": "22px",
+                        "display": "flex", "flexWrap": "wrap", "gap": "8px 16px",
+                    },
+                ),
+                dcc.Loading(
+                    id="loading-price",
+                    type="circle",
+                    children=dcc.Graph(
+                        id="price-chart",
+                        config={"displayModeBar": True, "responsive": True, "scrollZoom": True, "displaylogo": False},
+                    ),
+                ),
+            ],
+        ),
         html.Div(id="tab-content"),
     ],
 )
@@ -85,113 +194,18 @@ def render_tab(active_tab: str):
         return render_explorer()
     return html.P("Select a tab.", className="text-muted")
 
-def render_price_dashboard():
-    """Multi-asset candlestick chart with asset class, asset, interval, and time-range selectors."""
-    try:
-        range_options = [
-            {"label": "1 Day", "value": "1d"},
-            {"label": "3 Days", "value": "3d"},
-            {"label": "1 Week", "value": "7d"},
-            {"label": "1 Month", "value": "30d"},
-            {"label": "3 Months", "value": "90d"},
-            {"label": "6 Months", "value": "180d"},
-            {"label": "1 Year", "value": "365d"},
-            {"label": "All Data", "value": "all"},
-        ]
 
-        return dbc.Row(
-            dbc.Col(
-                [
-                    html.H3("Price Dashboard", className="text-light mb-3"),
-                    dbc.Row(
-                        [
-                            dbc.Col(
-                                [
-                                    html.Label("Asset Class", className="text-muted small mb-1"),
-                                    dcc.Dropdown(
-                                        id="price-class-dropdown",
-                                        options=[
-                                            {"label": "Crypto", "value": "crypto"},
-                                            {"label": "Stocks", "value": "stocks"},
-                                        ],
-                                        value="crypto",
-                                        clearable=False,
-                                        searchable=False,
-                                        style={"color": "#000"},
-                                    ),
-                                ],
-                                width=2,
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Label("Asset", className="text-muted small mb-1"),
-                                    dcc.Dropdown(
-                                        id="price-asset-dropdown",
-                                        clearable=False,
-                                        searchable=True,
-                                        style={"color": "#000"},
-                                    ),
-                                ],
-                                width=2,
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Label("Interval", className="text-muted small mb-1"),
-                                    dcc.Dropdown(
-                                        id="price-interval-dropdown",
-                                        clearable=False,
-                                        searchable=False,
-                                        style={"color": "#000"},
-                                    ),
-                                ],
-                                width=2,
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Label("Time Range", className="text-muted small mb-1"),
-                                    dcc.Dropdown(
-                                        id="price-range-dropdown",
-                                        options=range_options,
-                                        value="7d",
-                                        clearable=False,
-                                        searchable=False,
-                                        style={"color": "#000"},
-                                    ),
-                                ],
-                                width=2,
-                            ),
-                        ],
-                        className="mb-3",
-                    ),
-                    dbc.Checklist(
-                        id="indicator-toggles",
-                        options=[
-                            {"label": "EMA 9", "value": "ema9"},
-                            {"label": "EMA 21", "value": "ema21"},
-                            {"label": "EMA 50", "value": "ema50"},
-                            {"label": "SMA 50", "value": "sma50"},
-                            {"label": "SMA 200", "value": "sma200"},
-                            {"label": "Bollinger Bands", "value": "bb"},
-                            {"label": "VWAP", "value": "vwap"},
-                        ],
-                        value=[],
-                        inline=True,
-                        className="mb-3",
-                    ),
-                    dcc.Loading(
-                        id="loading-price",
-                        type="circle",
-                        children=dcc.Graph(
-                            id="price-chart",
-                            config={"displayModeBar": True, "responsive": True, "scrollZoom": True, "displaylogo": False},
-                        ),
-                    ),
-                ],
-                width=12,
-            )
-        )
-    except Exception as e:
-        return dbc.Alert(f"Error: {e}", color="danger")
+@app.callback(
+    dash.Output("price-chart-area", "style"),
+    dash.Input("main-tabs", "active_tab"),
+)
+def toggle_price_chart_area(active_tab):
+    if active_tab == "tab-price":
+        return {"display": "block"}
+    return {"display": "none"}
+
+def render_price_dashboard():
+    return None
 
 def render_predictions():
     """XGBoost model predictions with asset class, asset, and interval selectors."""
@@ -619,12 +633,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name=symbol_label,
             increasing_line_color="#26a69a",
             decreasing_line_color="#ef5350",
-            hovertemplate=(
-                f"O: %{{open:{price_fmt}}}<br>"
-                f"H: %{{high:{price_fmt}}}<br>"
-                f"L: %{{low:{price_fmt}}}<br>"
-                f"C: %{{close:{price_fmt}}}<extra></extra>"
-            ),
+            hovertemplate="<extra></extra>",
         ),
         row=1, col=1,
     )
@@ -637,7 +646,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             name="Volume",
             marker_color=colors,
             opacity=0.6,
-            hovertemplate="%{y:,.0f}<extra>Volume</extra>",
+            hoverinfo="skip",
         ),
         row=2, col=1,
     )
@@ -663,7 +672,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
                     x=df["date"], y=series,
                     mode="lines", name=cfg["name"],
                     line=dict(color=cfg["color"], width=1.2),
-                    hovertemplate=f"%{{y:.2f}}<extra>{cfg['name']}</extra>",
+                    hoverinfo="skip",
                 ),
                 row=1, col=1,
             )
@@ -673,9 +682,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             std20 = df["close"].rolling(window=20).std()
             bb_upper = sma20 + 2 * std20
             bb_lower = sma20 - 2 * std20
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8), hovertemplate="%{y:.2f}<extra>BB Upper</extra>"), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash"), hovertemplate="%{y:.2f}<extra>BB Mid</extra>"), row=1, col=1)
-            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)", hovertemplate="%{y:.2f}<extra>BB Lower</extra>"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_upper, mode="lines", name="BB Upper", line=dict(color="rgba(255,255,255,0.25)", width=0.8), hoverinfo="skip"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=sma20,   mode="lines", name="BB Mid",   line=dict(color="rgba(255,255,255,0.45)", width=0.8, dash="dash"), hoverinfo="skip"), row=1, col=1)
+            fig.add_trace(go.Scatter(x=df["date"], y=bb_lower, mode="lines", name="BB Lower", line=dict(color="rgba(255,255,255,0.25)", width=0.8), fill="tonexty", fillcolor="rgba(255,255,255,0.04)", hoverinfo="skip"), row=1, col=1)
 
         if "vwap" in indicators:
             typical = (df["high"] + df["low"] + df["close"]) / 3
@@ -685,7 +694,7 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             fig.add_trace(
                 go.Scatter(x=df["date"], y=vwap, mode="lines", name="VWAP",
                            line=dict(color="#ffeb3b", width=1, dash="dot"),
-                           hovertemplate="%{y:.2f}<extra>VWAP</extra>"),
+                           hoverinfo="skip"),
                 row=1, col=1,
             )
 
@@ -707,9 +716,9 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
             showspikes=True,
             spikemode="across",
             spikesnap="cursor",
-            spikethickness=2,
-            spikecolor="rgba(255,255,255,0.25)",
-            spikedash="dot",
+            spikethickness=1,
+            spikecolor="rgba(255,255,255,0.5)",
+            spikedash="dashdot",
             rangeselector=dict(
                 buttons=list([
                     dict(count=1, label="1D", step="day", stepmode="backward"),
@@ -741,16 +750,39 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     fig.update_yaxes(
         title_text="Price (USD)", row=1, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.06)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=2, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.5)", spikedash="dashdot",
         tickformat=price_fmt,
     )
     fig.update_yaxes(
         title_text="Volume", row=2, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.04)",
-        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=2, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.5)", spikedash="dashdot",
     )
 
     return fig
+
+
+@app.callback(
+    dash.Output("chart-info-bar", "children"),
+    dash.Input("price-chart", "hoverData"),
+)
+def update_chart_info_bar(hover_data):
+    """TradingView-style info bar: OHLCV + indicator values pinned above chart."""
+    if not hover_data or not hover_data.get("points"):
+        return dash.no_update
+    ohlc_vals = {}
+    ind_vals = {}
+    for pt in hover_data["points"]:
+        if "open" in pt:
+            ohlc_vals = {"O": pt["open"], "H": pt["high"], "L": pt["low"], "C": pt["close"]}
+        elif pt.get("y") is not None and pt.get("curveNumber", 0) > 1:
+            ind_vals[pt.get("name", "?")] = pt["y"]
+    parts = []
+    if ohlc_vals:
+        parts.append(f"O: {ohlc_vals['O']:.4f}  H: {ohlc_vals['H']:.4f}  L: {ohlc_vals['L']:.4f}  C: {ohlc_vals['C']:.4f}")
+    for name, val in ind_vals.items():
+        parts.append(f"{name}: {val:.4f}")
+    return "  |  ".join(parts) if parts else ""
 
 
 @app.callback(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -698,6 +698,12 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
         xaxis=dict(
             showgrid=True,
             gridcolor="rgba(255,255,255,0.06)",
+            showspikes=True,
+            spikemode="across",
+            spikesnap="cursor",
+            spikethickness=1,
+            spikecolor="rgba(255,255,255,0.25)",
+            spikedash="dot",
             rangeselector=dict(
                 buttons=list([
                     dict(count=1, label="1D", step="day", stepmode="backward"),
@@ -729,10 +735,12 @@ def build_price_chart(asset_class, asset_symbol, interval, range_value, indicato
     fig.update_yaxes(
         title_text="Price (USD)", row=1, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.06)",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
     )
     fig.update_yaxes(
         title_text="Volume", row=2, col=1,
         showgrid=True, gridcolor="rgba(255,255,255,0.04)",
+        showspikes=True, spikemode="across", spikesnap="cursor", spikethickness=1, spikecolor="rgba(255,255,255,0.25)", spikedash="dot",
     )
 
     return fig


### PR DESCRIPTION
after #112 we did following updates in app.py ,

Candlestick Chart: Toggleable Indicator Overlays, Crosshair & Info Bar

added 7 toggleable technical indicators (EMA 9/21/50, SMA 50/200, Bollinger Bands, VWAP) as overlays on the candlestick chart via a horizontal checkbox list. Indicators computed in pure pandas and overlaid as go.Scatter traces on the price subplot. Legend auto-shows when any indicator is active.

replaced selection-box zoom with TradingView-style interaction: dragmode="pan" for drag-to-pan, scrollZoom: True for scroll-wheel candle/price zoom, and crosshair spikes with free cursor tracking (spikesnap="cursor").

replaced floating tooltips with a pinned info bar (html.Div) above the chart showing OHLCV + active indicator values on hover, using hovertemplate="<extra></extra>" to suppress tooltip boxes while preserving hover data for the callback.

moved all price-tab components (dropdowns, toggles, chart, loading wrapper) into the main layout to resolve "nonexistent object" callback errors when switching tabs. Price chart area auto-hides on non-price tabs.

fixed price axis to consistent 4-decimal formatting across all assets.

Next issue: Volume not appearing in the info bar ,candlestick customdata stores the volume array, and the info bar callback reads it. 

- Close #113 