### PR TITLE
122 add checkpointing to pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 data/raw/*
 data/processed/*
 data/analytics/*
+data/.pipeline_checkpoint.json
 
 *duckdb
 *.log

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Project involves both  **Data Engineering** and **Data Science** to analyze fina
 1. **Extract (Ingestion)**: Scripts download historical data from Yahoo Finance and Bybit APIs, standardizing timezones and saving the raw data locally as `.parquet` files.
 2. **Load (Storage)**: Raw Parquet files are loaded into a local **DuckDB** analytical database.
 3. **Transform (Processing)**: In-database SQL transformations clean the data (removing duplicates and filtering 0/negative prices), cast all dates to a unified timezone-naive `TIMESTAMP` format, and enforce strict chronological ordering for time-series modeling.
-4. **Analyze (Modeling)**: ML models (like ARIMA or LSTM) will use this clean data to find market trends.
+4. **Analyze (Modeling)**: ML models (XGBoost) use this clean data to predict market direction.
 
 ## Architecture
 
@@ -22,43 +22,56 @@ The project uses a **Medallion Data Lake Architecture** with three layers stored
    Cleaned and validated data stored as Parquet files. Duplicates removed, schemas enforced, timestamps normalized.
 
 3. **Gold Layer** (`s3://analytics-data/`)  
-   Analytics table (`ml_features.parquet`) with 49 calculated features including moving averages, RSI, MACD, Bollinger Bands, VWAP, and return features. Ready for machine learning and dashboards.
+   Separate analytics tables for crypto and stocks (`gold_crypto_analytics`, `gold_stock_analytics`) with calculated features including moving averages, RSI, MACD, Bollinger Bands, VWAP, and technical indicators. Also includes feature tables and prediction tables. Ready for dashboards and ML.
 
 ### Services
 
 - **MinIO**: S3-compatible object storage (Ports: 9000 for API, 9001 for web console)
-- **Python Pipeline**: Automated ELT orchestration (executes on startup + scheduled daily at 00:00 UTC)
+- **Prefect**: Flow orchestration with task-level retries and checkpoint/resume recovery (Port: 4200)
+- **Python Pipeline**: Automated ELT orchestration using Prefect (executes on startup + scheduled hourly)
+- **Plotly Dash**: Interactive dashboard with 5 tabs — Price, Predictions, Backtest, Indicators, Data Explorer (Port: 8050)
 - **Apache Superset**: Interactive BI dashboard for data visualization (Port: 8088)
+- **MLflow**: ML experiment tracking (Port: 5000)
 - **DuckDB**: In-process analytical database for SQL transformations
 
 ## Project Structure
 
+- **`backtesting/`**  
+  Walk-forward validation with trade simulation and performance metrics.
+
 - **`configs/`**  
   Settings for the project, like API keys and database paths.
+
+- **`dashboard/`**  
+  Plotly Dash web application (`app.py`) with XGBoost predictor (`predictor.py`).
 
 - **`notebooks/`**  
   Jupyter notebooks where test ideas and visualize data before writing the final code.
 
 - **`orchestration/`**  
-  Contains the main scripts that run the whole pipeline automatically (e.g., download -> clean -> save).
+  Contains the main Prefect flow and checkpoint/resume logic that runs the whole pipeline automatically.
 
 - **`scripts/`**
-  Contains Python scripts for data analysis:
-  - eda_ml.py: Checks data volume and readiness for ML.
-  - top15_feat.py: Finds top 15 important features.
-  - target_analysis.py: Analyzes the target variable (returns_1d).
-
+  Contains Python scripts for data analysis and model training:
+  - `train_btc_model.py`: Trains XGBoost model for BTC.
+  - `train_aapl_model.py`: Trains XGBoost model for AAPL.
+  - `eda_ml.py`: Checks data volume and readiness for ML.
+  - `top15_feat.py`: Finds top 15 important features.
+  - `target_analysis.py`: Analyzes the target variable (returns_1d).
 
 - **`src/`**  
   The main source code for the project:
-  - `ingestion/`: API configuration and Parquet extraction (`yahoo_finance.py`, `bybit_client.py`).
-  - `database/`: DuckDB connection and loading logic (`loader.py`).
+  - `ingestion/`: API clients for Yahoo Finance (`yahoo_finance.py`) and Bybit (`bybit_client.py`).
+  - `database/`: DuckDB loading (`loader.py`), dimensional modeling (`dimensions.py`), and fact tables (`facts.py`).
   - `processing/`: Data scaling, cleaning, and chronological transformation (`transformation.py`).
-  - `models/`: The Machine Learning logic for predictions.
+  - `models/`: Gold layer processor, technical indicators processor, and feature analyzer.
   - `utils/`: Helper scripts (like custom console logging).
 
 - **`tests/`**  
   Simple tests to make sure the code is working correctly.
+
+- **`reports/`**  
+  Generated market and ML profile reports.
 
 ## how to Run
 
@@ -76,7 +89,8 @@ The project uses a **Medallion Data Lake Architecture** with three layers stored
 
 4. **Run the pipeline:**
     ```bash
-    python -m orchestration.orchestration
+    python -m orchestration.orchestration             # Normal run (resumes from checkpoint)
+    python -m orchestration.orchestration --force     # Force full re-run (clears checkpoint)
     ```
 
 ### Running with Docker

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -592,6 +592,7 @@ def _build_backtest_results(metrics, equity_df, trades_df):
         template="plotly_dark", paper_bgcolor="rgba(0,0,0,0)", plot_bgcolor="rgba(0,0,0,0)",
         height=400, title="Equity Curve", hovermode="x unified",
         margin=dict(l=10, r=10, t=40, b=10),
+        dragmode="pan",
     )
     fig_equity.update_yaxes(title_text="Equity ($)")
 
@@ -624,6 +625,7 @@ def _build_backtest_results(metrics, equity_df, trades_df):
         template="plotly_dark", paper_bgcolor="rgba(0,0,0,0)", plot_bgcolor="rgba(0,0,0,0)",
         height=400, title="Trade PnL (% per trade)", hovermode="closest",
         margin=dict(l=10, r=10, t=40, b=10),
+        dragmode="pan",
     )
     fig_trades.update_yaxes(title_text="PnL (%)")
 
@@ -1660,6 +1662,7 @@ def build_prediction_charts(asset_class, asset_symbol, interval, range_value):
         plot_bgcolor="rgba(0,0,0,0)",
         height=650,
         hovermode="x unified",
+        dragmode="pan",
         hoverlabel=dict(bgcolor="#212529", font_size=13),
         showlegend=True,
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
@@ -1685,6 +1688,7 @@ def build_prediction_charts(asset_class, asset_symbol, interval, range_value):
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(0,0,0,0)",
         height=350,
+        dragmode="pan",
         hoverlabel=dict(bgcolor="#212529", font_size=13),
         title="Confidence Distribution",
         xaxis_title="Prediction Confidence",
@@ -1992,6 +1996,7 @@ def build_indicators_chart(asset_class, asset_symbol, interval, range_value):
         plot_bgcolor="rgba(0,0,0,0)",
         height=1200,
         hovermode="x unified",
+        dragmode="pan",
         hoverlabel=dict(bgcolor="#212529", font_size=13),
         showlegend=True,
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),

--- a/orchestration/orchestration.py
+++ b/orchestration/orchestration.py
@@ -136,16 +136,31 @@ def run_pipeline():
     logger.info("=== Financial Data Pipeline (ELT) Starting ===")
     pipeline_start = time.time()
 
+    if FORCE_FLAG:
+        _clear_checkpoint()
+        logger.info("--force detected: cleared checkpoint, running all steps")
+
     with open("configs/settings.yml", "r") as f:
         config = yaml.safe_load(f)
 
-    extract_data(config)
-    load_to_duckdb()
-    transform_clean()
-    build_dimensions()
-    load_facts()
-    build_gold_layer()
-    build_technical_indicators()
+    steps = [
+        ("step1_extract",    lambda: extract_data(config)),
+        ("step2_load",       lambda: load_to_duckdb()),
+        ("step3_clean",      lambda: transform_clean()),
+        ("step4_dimensions", lambda: build_dimensions()),
+        ("step5_facts",      lambda: load_facts()),
+        ("step6_gold",       lambda: build_gold_layer()),
+        ("step7_indicators", lambda: build_technical_indicators()),
+    ]
+
+    for step_id, step_fn in steps:
+        if _should_run(step_id, FORCE_FLAG):
+            logger.info(f"[CHECKPOINT] Running {step_id}...")
+            step_fn()
+            _mark_done(step_id)
+            logger.info(f"[CHECKPOINT] {step_id} complete — saved")
+        else:
+            logger.info(f"[CHECKPOINT] Skipping {step_id} (already done)")
 
     elapsed = time.time() - pipeline_start
     logger.info(f"=== Pipeline executed successfully in {elapsed:.1f}s ===")

--- a/orchestration/orchestration.py
+++ b/orchestration/orchestration.py
@@ -1,12 +1,48 @@
 import yaml
 import time
 import gc
+import json
+import sys
+from pathlib import Path
 from prefect import flow, task, get_run_logger
 from src.utils import get_logger
 from src.ingestion import YahooFinanceClient, BybitClient
 from src.database import DatabaseLoader, DimensionBuilder, FactLoader
 from src.processing import DataCleaner
 from src.models import GoldLayerProcessor, TechnicalIndicatorProcessor
+
+CHECKPOINT_FILE = Path("data/.pipeline_checkpoint.json")
+
+
+def _load_checkpoint() -> set:
+    if CHECKPOINT_FILE.exists():
+        return set(json.loads(CHECKPOINT_FILE.read_text()))
+    return set()
+
+
+def _save_checkpoint(completed: set):
+    CHECKPOINT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CHECKPOINT_FILE.write_text(json.dumps(list(completed)))
+
+
+def _clear_checkpoint():
+    if CHECKPOINT_FILE.exists():
+        CHECKPOINT_FILE.unlink()
+
+
+def _should_run(step: str, force: bool) -> bool:
+    if force:
+        return True
+    return step not in _load_checkpoint()
+
+
+def _mark_done(step: str):
+    completed = _load_checkpoint()
+    completed.add(step)
+    _save_checkpoint(completed)
+
+
+FORCE_FLAG = "--force" in sys.argv
 
 
 @task(name="extract-data", retries=2, retry_delay_seconds=30)

--- a/orchestration/orchestration.py
+++ b/orchestration/orchestration.py
@@ -164,6 +164,7 @@ def run_pipeline():
 
     elapsed = time.time() - pipeline_start
     logger.info(f"=== Pipeline executed successfully in {elapsed:.1f}s ===")
+    _clear_checkpoint()
     gc.collect()
 
 


### PR DESCRIPTION
## Summary
- added Prefect pipeline checkpoint/resume system — failed runs skip already-completed steps on restart
- auto-clears checkpoint on full pipeline success so scheduled runs start fresh
- `--force` flag available for manual full re-runs
- all dashboard charts default to pan mode instead of zoom (6 charts across 5 tabs)
- `.pipeline_checkpoint.json` added to `.gitignore`
- updated readme

## files changed
- `orchestration/orchestration.py` — checkpoint helpers + flow integration
- `dashboard/app.py` — `dragmode="pan"` on all interactive charts
- `.gitignore` — exclude checkpoint file
- README.md

- Close #122 