### PR TITLE
124 add stock backtesting support to the dashboard

### DIFF
--- a/backtesting/walk_forward.py
+++ b/backtesting/walk_forward.py
@@ -61,7 +61,7 @@ def _make_stationary(df):
     return df
 
 
-def _load_data(asset="BTC", interval="1h", date_start=None, date_end=None):
+def _load_data(asset="BTC", interval="1h", date_start=None, date_end=None, asset_class="crypto"):
     conn = duckdb.connect(DB_PATH, read_only=True)
     needed_cols = [
         "date", "close",
@@ -76,9 +76,11 @@ def _load_data(asset="BTC", interval="1h", date_start=None, date_end=None):
     ]
     col_list = ", ".join(needed_cols)
 
+    table = "gold_crypto_features" if asset_class.lower() == "crypto" else "gold_stock_features"
+
     query = f"""
         SELECT {col_list}
-        FROM gold_crypto_features
+        FROM {table}
         WHERE asset_symbol = '{asset}' AND interval = '{interval}'
     """
     if date_start:
@@ -160,16 +162,17 @@ def _prepare_fold_data(train_df, test_df):
     return X_train, y_train, X_test, y_test, test_df.loc[X_test.index], available_feats
 
 
-def run_walk_forward(asset="BTC", interval="1h", train_months=6, test_months=1, step_months=1, date_start=None, date_end=None, return_data=False):
+def run_walk_forward(asset="BTC", interval="1h", train_months=6, test_months=1, step_months=1, date_start=None, date_end=None, return_data=False, asset_class="crypto"):
     print(f"\n=== Walk-Forward Backtest: {asset} {interval} ===")
     print(f"   Train window: {train_months} months")
     print(f"   Test window:  {test_months} months")
-    print(f"   Step:         {step_months} months\n")
+    print(f"   Step:         {step_months} months")
+    print(f"   Asset class:  {asset_class}\n")
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-    print("[1/4] Loading data from gold_crypto_features...")
-    df = _load_data(asset, interval, date_start, date_end)
+    print(f"[1/4] Loading data from gold_{asset_class}_features...")
+    df = _load_data(asset, interval, date_start, date_end, asset_class)
     print(f"   Loaded {len(df):,} rows ({df['date'].min().date()} to {df['date'].max().date()})")
 
     print("\n[2/4] Generating walk-forward folds...")

--- a/backtesting/walk_forward.py
+++ b/backtesting/walk_forward.py
@@ -291,5 +291,139 @@ def run_walk_forward(asset="BTC", interval="1h", train_months=6, test_months=1, 
     return combined, fold_summaries
 
 
+def run_walk_forward_pretrained(
+    asset="BTC", interval="1h", train_months=6, test_months=1, step_months=1,
+    date_start=None, date_end=None, return_data=False, asset_class="crypto",
+):
+    model_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "src", "models", f"{asset}_{interval}_xgboost_model.json",
+    )
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"No pre-trained model found for {asset} {interval} at {model_path}. "
+            f"Train it first with scripts/train_{asset.lower()}_model.py"
+        )
+
+    print(f"\n=== Pre-trained Model Backtest: {asset} {interval} ===")
+    print(f"   Model: {model_path}")
+    print(f"   Train window: {train_months} months (used only for fold boundaries)")
+    print(f"   Test window:  {test_months} months")
+    print(f"   Step:         {step_months} months")
+    print(f"   Asset class:  {asset_class}\n")
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    print(f"[1/4] Loading pre-trained model...")
+    pt_model = xgb.XGBClassifier()
+    pt_model.load_model(model_path)
+    print(f"   Loaded from {model_path}")
+
+    print(f"[2/4] Loading data from gold_{asset_class}_features...")
+    df = _load_data(asset, interval, date_start, date_end, asset_class)
+    print(f"   Loaded {len(df):,} rows ({df['date'].min().date()} to {df['date'].max().date()})")
+
+    print("\n[3/4] Generating walk-forward folds...")
+    folds = _generate_folds(df, train_months, test_months, step_months)
+    print(f"   Created {len(folds)} folds")
+
+    if len(folds) == 0:
+        raise RuntimeError(f"Not enough data. Need at least {train_months + test_months} months.")
+
+    all_predictions = []
+    fold_summaries = []
+
+    print("\n[4/4] Running pre-trained model on each fold...")
+    for fold in folds:
+        fid = fold["fold_id"]
+        test_df = fold["test_df"]
+
+        test_df = _make_stationary(test_df)
+        test_df["target_direction"] = (test_df["close"].shift(-1) > test_df["close"]).astype(int)
+        test_df = test_df.dropna(subset=["target_direction"])
+
+        available_feats = [f for f in MODEL_FEATURES if f in test_df.columns]
+        X_test = test_df[available_feats].dropna()
+        y_test = test_df.loc[X_test.index, "target_direction"]
+
+        if len(X_test) < 20:
+            print(f"   Fold {fid}: SKIP (only {len(X_test)} rows after dropna)")
+            continue
+
+        y_pred = pt_model.predict(X_test)
+        probs = pt_model.predict_proba(X_test)
+        up_prob = probs[:, 1]
+        confidence = np.where(y_pred == 1, up_prob, 1 - up_prob)
+
+        fold_acc = accuracy_score(y_test, y_pred)
+
+        predictions = test_df.loc[X_test.index, ["date", "close"]].copy()
+        predictions["prediction"] = y_pred
+        predictions["confidence"] = confidence
+        predictions["actual_direction"] = y_test.values
+        predictions["fold_id"] = fid
+        predictions["train_start"] = fold["train_start"]
+        predictions["train_end"] = fold["train_end"]
+        predictions["test_start"] = fold["test_start"]
+        predictions["test_end"] = fold["test_end"]
+
+        all_predictions.append(predictions)
+
+        fold_summaries.append({
+            "fold_id": fid,
+            "train_start": str(fold["train_start"].date()),
+            "train_end": str(fold["train_end"].date()),
+            "test_start": str(fold["test_start"].date()),
+            "test_end": str(fold["test_end"].date()),
+            "train_rows": fold["train_rows"],
+            "test_rows": fold["test_rows"],
+            "test_rows_after_dropna": len(X_test),
+            "accuracy": round(fold_acc, 4),
+            "features_used": available_feats,
+        })
+
+        print(f"   Fold {fid}: {fold['test_start'].date()} to {fold['test_end'].date()}"
+              f" ({len(X_test):,} rows) | Accuracy: {fold_acc:.4f} ({fold_acc*100:.2f}%)")
+
+    if not all_predictions:
+        raise RuntimeError("No folds produced valid predictions. Check date range and data.")
+
+    combined = pd.concat(all_predictions, ignore_index=True)
+    combined = combined.sort_values("date").reset_index(drop=True)
+
+    overall_acc = (combined["prediction"] == combined["actual_direction"]).mean()
+    summary = {
+        "asset": asset,
+        "interval": interval,
+        "model_path": model_path,
+        "train_months": train_months,
+        "test_months": test_months,
+        "step_months": step_months,
+        "total_folds": len(fold_summaries),
+        "total_predictions": len(combined),
+        "overall_accuracy": round(overall_acc, 4),
+        "folds": fold_summaries,
+    }
+
+    print(f"\n=== Done ===")
+    print(f"   Folds completed: {len(fold_summaries)}")
+    print(f"   Total OOS predictions: {len(combined):,}")
+    print(f"   Overall accuracy: {overall_acc:.4f} ({overall_acc*100:.2f}%)")
+
+    if return_data:
+        return combined, summary
+
+    pred_path = os.path.join(OUTPUT_DIR, "walk_forward_predictions_pretrained.parquet")
+    combined.to_parquet(pred_path)
+    print(f"   Predictions saved: {pred_path}")
+
+    summary_path = os.path.join(OUTPUT_DIR, "walk_forward_summary_pretrained.json")
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"   Summary saved: {summary_path}")
+
+    return combined, fold_summaries
+
+
 if __name__ == "__main__":
     run_walk_forward()

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -690,10 +690,6 @@ def run_backtest_pipeline(set_progress, n_clicks, asset_class, asset, interval,
     try:
         set_progress(dbc.Alert("Loading data & training walk-forward model...", color="info"))
 
-        if asset_class == "stocks":
-            set_progress(dbc.Alert("Stock backtesting not yet supported. Please select Crypto.", color="warning"))
-            return html.Div()
-
         from backtesting.walk_forward import run_walk_forward
         from backtesting.strategy import run_strategy
         from backtesting.metrics import run_metrics
@@ -707,6 +703,7 @@ def run_backtest_pipeline(set_progress, n_clicks, asset_class, asset, interval,
             date_start=date_start if date_start else None,
             date_end=date_end if date_end else None,
             return_data=True,
+            asset_class=asset_class,
         )
 
         if predictions_df.empty:

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -396,6 +396,22 @@ def render_backtest():
                     [
                         dbc.Col(
                             [
+                                html.Label("Backtest Mode", className="text-muted small mb-1"),
+                                dcc.RadioItems(
+                                    id="bt-mode-radio",
+                                    options=[
+                                        {"label": "Walk-Forward (retrain/fold)", "value": "walk_forward"},
+                                        {"label": "Pre-trained Model", "value": "pretrained"},
+                                    ],
+                                    value="walk_forward",
+                                    labelStyle={"display": "block", "color": "#adb5bd", "fontSize": "12px"},
+                                    inputStyle={"marginRight": "6px"},
+                                ),
+                            ],
+                            width=2,
+                        ),
+                        dbc.Col(
+                            [
                                 html.Label("Asset Class", className="text-muted small mb-1"),
                                 dcc.Dropdown(
                                     id="bt-class-dropdown",
@@ -662,6 +678,7 @@ def _build_backtest_results(metrics, equity_df, trades_df):
 @app.callback(
     dash.Output("bt-results", "children"),
     dash.Input("bt-run-btn", "n_clicks"),
+    dash.State("bt-mode-radio", "value"),
     dash.State("bt-class-dropdown", "value"),
     dash.State("bt-asset-dropdown", "value"),
     dash.State("bt-interval-dropdown", "value"),
@@ -680,7 +697,7 @@ def _build_backtest_results(metrics, equity_df, trades_df):
     progress=[dash.Output("bt-progress-bar", "children")],
     prevent_initial_call=True,
 )
-def run_backtest_pipeline(set_progress, n_clicks, asset_class, asset, interval,
+def run_backtest_pipeline(set_progress, n_clicks, bt_mode, asset_class, asset, interval,
                            date_start, date_end, confidence, stop_loss, take_profit,
                            max_hold, capital, train_months, test_months, step_months):
     """Background callback: runs the full walk-forward → strategy → metrics pipeline."""
@@ -688,23 +705,39 @@ def run_backtest_pipeline(set_progress, n_clicks, asset_class, asset, interval,
         raise dash.exceptions.PreventUpdate
 
     try:
-        set_progress(dbc.Alert("Loading data & training walk-forward model...", color="info"))
+        if bt_mode == "pretrained":
+            set_progress(dbc.Alert("Loading pre-trained model...", color="info"))
+        else:
+            set_progress(dbc.Alert("Loading data & training walk-forward model...", color="info"))
 
-        from backtesting.walk_forward import run_walk_forward
+        from backtesting.walk_forward import run_walk_forward, run_walk_forward_pretrained
         from backtesting.strategy import run_strategy
         from backtesting.metrics import run_metrics
 
-        predictions_df, _summary = run_walk_forward(
-            asset=asset,
-            interval=interval,
-            train_months=int(train_months),
-            test_months=int(test_months),
-            step_months=int(step_months),
-            date_start=date_start if date_start else None,
-            date_end=date_end if date_end else None,
-            return_data=True,
-            asset_class=asset_class,
-        )
+        if bt_mode == "pretrained":
+            predictions_df, _summary = run_walk_forward_pretrained(
+                asset=asset,
+                interval=interval,
+                train_months=int(train_months),
+                test_months=int(test_months),
+                step_months=int(step_months),
+                date_start=date_start if date_start else None,
+                date_end=date_end if date_end else None,
+                return_data=True,
+                asset_class=asset_class,
+            )
+        else:
+            predictions_df, _summary = run_walk_forward(
+                asset=asset,
+                interval=interval,
+                train_months=int(train_months),
+                test_months=int(test_months),
+                step_months=int(step_months),
+                date_start=date_start if date_start else None,
+                date_end=date_end if date_end else None,
+                return_data=True,
+                asset_class=asset_class,
+            )
 
         if predictions_df.empty:
             return dbc.Alert("No predictions generated. Check date range and asset.", color="warning")


### PR DESCRIPTION
added stock backtesting support + pre-trained model backtest mode

- backtesting/walk_forward.py: Added asset_class param for stocks (gold_stock_features); added run_walk_forward_pretrained() to test trained JSON models without retraining per fold
 
- dashboard/app.py: Removed "stocks not supported" block; added mode toggle (Walk-Forward / Pre-trained Model) in Backtest tab

- Close #124 