### PR TITLE
180 add interactive feature importance chart to dashboard

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -294,6 +294,8 @@ def render_tab(active_tab: str):
         return render_explorer()
     elif active_tab == "tab-model-health":
         return render_model_health()
+    elif active_tab == "tab-feature-importance":
+        return render_feature_importance()
     return html.P("Select a tab.", className="text-muted")
 
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -157,6 +157,7 @@ app.layout = dbc.Container(
                 dbc.Tab(label=" Technical Indicators", tab_id="tab-indicators"),
                 dbc.Tab(label=" Data Explorer", tab_id="tab-explorer"),
                 dbc.Tab(label=" Model Health", tab_id="tab-model-health"),
+                dbc.Tab(label=" Feature Importance", tab_id="tab-feature-importance"),
             ],
         ),
         html.Hr(),

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -294,8 +294,8 @@ def render_tab(active_tab: str):
         return render_explorer()
     elif active_tab == "tab-model-health":
         return render_model_health()
-    elif active_tab == "tab-feature-importance":
-        return render_feature_importance()
+    elif active_tab == "tab-model-insights":
+        return render_model_insights()
     return html.P("Select a tab.", className="text-muted")
 
 
@@ -1456,8 +1456,8 @@ def render_model_health():
         table,
     ])
 
-def render_feature_importance():
-    """Interactive feature importance chart for any of the 45 trained models."""
+def render_model_insights():
+    """Interactive model insights — feature importance, accuracy chart, confusion matrix."""
     return html.Div([
         html.H3("Feature Importance", className="text-light mb-3"),
         dbc.Row([

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1456,6 +1456,48 @@ def render_model_health():
         table,
     ])
 
+def render_feature_importance():
+    """Interactive feature importance chart for any of the 45 trained models."""
+    return html.Div([
+        html.H3("Feature Importance", className="text-light mb-3"),
+        dbc.Row([
+            dbc.Col([
+                html.Label("Asset Class", className="text-muted small mb-1"),
+                dcc.Dropdown(
+                    id="fi-class-dropdown",
+                    options=[
+                        {"label": "Crypto", "value": "crypto"},
+                        {"label": "Stocks", "value": "stocks"},
+                    ],
+                    value="crypto",
+                    clearable=False,
+                    style={"color": "#000"},
+                ),
+            ], width=3),
+            dbc.Col([
+                html.Label("Asset", className="text-muted small mb-1"),
+                dcc.Dropdown(
+                    id="fi-asset-dropdown",
+                    clearable=False,
+                    style={"color": "#000"},
+                ),
+            ], width=3),
+            dbc.Col([
+                html.Label("Interval", className="text-muted small mb-1"),
+                dcc.Dropdown(
+                    id="fi-interval-dropdown",
+                    clearable=False,
+                    style={"color": "#000"},
+                ),
+            ], width=3),
+        ], className="mb-3"),
+        dcc.Loading(
+            id="fi-loading",
+            type="circle",
+            children=html.Div(id="fi-chart-container"),
+        ),
+    ])
+
 PRICE_RANGE_MAP = {
     "1d": 1, "3d": 3, "7d": 7, "30d": 30,
     "90d": 90, "180d": 180, "365d": 365,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2754,5 +2754,115 @@ def update_stock_freshness(_n):
     except Exception:
         return dbc.Badge("Stocks: unavailable", color="secondary", className="px-3 py-2 fs-6")
 
+
+@app.callback(
+    dash.Output("fi-asset-dropdown", "options"),
+    dash.Output("fi-asset-dropdown", "value"),
+    dash.Input("fi-class-dropdown", "value"),
+)
+def update_fi_asset_dropdown(asset_class):
+    if asset_class == "crypto":
+        assets = CRYPTO_ASSETS
+        default = "BTC" if "BTC" in assets else (assets[0] if assets else None)
+    else:
+        assets = STOCK_ASSETS
+        default = assets[0] if assets else None
+    options = [{"label": a, "value": a} for a in assets]
+    return options, default
+
+
+@app.callback(
+    dash.Output("fi-interval-dropdown", "options"),
+    dash.Output("fi-interval-dropdown", "value"),
+    dash.Input("fi-class-dropdown", "value"),
+)
+def update_fi_interval_dropdown(asset_class):
+    if asset_class == "crypto":
+        intervals = CRYPTO_INTERVALS
+        default = "1h"
+    else:
+        intervals = STOCK_INTERVALS
+        default = "1h"
+    options = [{"label": INTERVAL_LABELS.get(iv, iv), "value": iv} for iv in intervals]
+    return options, default
+
+
+@app.callback(
+    dash.Output("fi-chart-container", "children"),
+    dash.Input("fi-class-dropdown", "value"),
+    dash.Input("fi-asset-dropdown", "value"),
+    dash.Input("fi-interval-dropdown", "value"),
+)
+def build_feature_importance_chart(asset_class, asset_symbol, interval):
+    import json
+    import xgboost as xgb
+
+    if not asset_symbol or not interval:
+        return dbc.Alert("Select an asset and interval.", color="info")
+
+    subdir = "crypto" if asset_class == "crypto" else "stocks"
+    model_path = os.path.join("src", "models", subdir, f"{asset_symbol}_{interval}_xgboost_model.json")
+    meta_path = os.path.join("src", "models", subdir, f"{asset_symbol}_{interval}_xgboost_metadata.json")
+
+    if not os.path.exists(model_path):
+        return dbc.Alert(
+            f"No trained model found for {asset_symbol} @ {interval}. Run the pipeline first.",
+            color="warning",
+        )
+
+    try:
+        model = xgb.XGBClassifier()
+        model.load_model(model_path)
+        booster = model.get_booster()
+
+        importance = booster.get_score(importance_type="gain")
+        if not importance:
+            importance = booster.get_score(fmap="", importance_type="gain")
+
+        if not importance:
+            if os.path.exists(meta_path):
+                with open(meta_path) as f:
+                    meta = json.load(f)
+                features = meta.get("features", [])
+                scores = model.feature_importances_
+                importance = {feat: score for feat, score in zip(features, scores) if score > 0}
+            else:
+                importance = {}
+
+        if not importance:
+            return dbc.Alert(
+                f"No feature importance data available for {asset_symbol} @ {interval}.",
+                color="warning",
+            )
+
+        sorted_items = sorted(importance.items(), key=lambda x: x[1], reverse=True)[:15]
+        feat_names = [x[0] for x in sorted_items]
+        feat_values = [x[1] for x in sorted_items]
+
+        fig = go.Figure(go.Bar(
+            x=feat_values,
+            y=feat_names,
+            orientation="h",
+            marker_color="#3498db",
+            text=[f"{v:.2f}" for v in feat_values],
+            textposition="outside",
+        ))
+        fig.update_layout(
+            template="plotly_dark",
+            title=f"Top 15 Feature Importance (Gain) - {asset_symbol} {interval}",
+            xaxis_title="Feature Importance (Gain)",
+            yaxis=dict(autorange="reversed"),
+            paper_bgcolor="rgba(0,0,0,0)",
+            plot_bgcolor="rgba(0,0,0,0)",
+            height=500,
+            margin=dict(l=160, r=40, t=60, b=40),
+        )
+
+        return dcc.Graph(figure=fig, config={"displayModeBar": False})
+
+    except Exception as e:
+        return dbc.Alert(f"Error loading feature importance: {e}", color="danger")
+
+
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0", port=8050)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -157,7 +157,7 @@ app.layout = dbc.Container(
                 dbc.Tab(label=" Technical Indicators", tab_id="tab-indicators"),
                 dbc.Tab(label=" Data Explorer", tab_id="tab-explorer"),
                 dbc.Tab(label=" Model Health", tab_id="tab-model-health"),
-                dbc.Tab(label=" Feature Importance", tab_id="tab-feature-importance"),
+                dbc.Tab(label=" Model Insights", tab_id="tab-model-insights"),
             ],
         ),
         html.Hr(),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -162,3 +162,72 @@ class TestPredictionCards:
         xgboost_row = comparison_tables[0].loc[comparison_tables[0]["Model / Rule"] == "XGBoost"].iloc[0]
         assert xgboost_row["Correct"] == 1
         assert xgboost_row["Rows Tested"] == 2
+
+
+class TestFeatureImportance:
+    def test_missing_model_shows_warning(self):
+        from dashboard import app as dashboard_app
+
+        with patch("os.path.exists", return_value=False):
+            result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
+
+        text = _collect_text(result)
+        assert any("No trained model" in t for t in text)
+
+    def test_chart_shows_top_features(self):
+        from dashboard import app as dashboard_app
+
+        mock_booster = MagicMock()
+        mock_booster.get_score.return_value = {
+            "sma_7_dist": 15.2,
+            "rsi_14": 12.1,
+            "volume_ratio": 8.5,
+            "returns_1p": 5.3,
+            "macd": 3.1,
+        }
+        mock_model = MagicMock()
+        mock_model.get_booster.return_value = mock_booster
+
+        with patch("os.path.exists", return_value=True):
+            with patch("xgboost.XGBClassifier", return_value=mock_model):
+                result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
+
+        assert hasattr(result, "figure")
+        bar_trace = result.figure.data[0]
+        assert bar_trace.orientation == "h"
+        assert "sma_7_dist" in list(bar_trace.y)
+        assert "rsi_14" in list(bar_trace.y)
+        assert len(bar_trace.y) == 5
+
+    def test_chart_limits_to_top_15(self):
+        from dashboard import app as dashboard_app
+
+        fake_importance = {f"feature_{i}": float(100 - i) for i in range(20)}
+        mock_booster = MagicMock()
+        mock_booster.get_score.return_value = fake_importance
+        mock_model = MagicMock()
+        mock_model.get_booster.return_value = mock_booster
+
+        with patch("os.path.exists", return_value=True):
+            with patch("xgboost.XGBClassifier", return_value=mock_model):
+                result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
+
+        bar_trace = result.figure.data[0]
+        assert len(bar_trace.y) == 15
+        assert "feature_0" in list(bar_trace.y)
+        assert "feature_19" not in list(bar_trace.y)
+
+    def test_title_includes_asset_and_interval(self):
+        from dashboard import app as dashboard_app
+
+        mock_booster = MagicMock()
+        mock_booster.get_score.return_value = {"rsi_14": 10.0}
+        mock_model = MagicMock()
+        mock_model.get_booster.return_value = mock_booster
+
+        with patch("os.path.exists", return_value=True):
+            with patch("xgboost.XGBClassifier", return_value=mock_model):
+                result = dashboard_app.build_feature_importance_chart("stocks", "AAPL", "1d")
+
+        assert "AAPL" in result.figure.layout.title.text
+        assert "1d" in result.figure.layout.title.text

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,6 +7,7 @@ import pytest
 import os
 import pandas as pd
 from unittest.mock import patch, MagicMock
+
 from dashboard.predictor import _discover_model, _INTERVAL_MINUTES, FEATURE_TABLES
 
 
@@ -187,17 +188,41 @@ class TestFeatureImportance:
         }
         mock_model = MagicMock()
         mock_model.get_booster.return_value = mock_booster
+        mock_model.load_model = MagicMock()
+
+        captured_bars = []
+
+        class FakeBar:
+            def __init__(self, **kwargs):
+                self.x = kwargs.get("x", [])
+                self.y = kwargs.get("y", [])
+                self.orientation = kwargs.get("orientation", "v")
+                captured_bars.append(self)
+
+        class FakeFig:
+            def __init__(self, bar):
+                self.data = (bar,)
+                self.layout = MagicMock()
+            def update_layout(self, **kwargs):
+                self.title_text = kwargs.get("title", "")
+
+        def mock_graph(**kwargs):
+            mock_obj = MagicMock()
+            mock_obj.figure = kwargs.get("figure")
+            return mock_obj
 
         with patch("os.path.exists", return_value=True):
             with patch("xgboost.XGBClassifier", return_value=mock_model):
-                result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
+                with patch.object(dashboard_app.go, "Bar", FakeBar):
+                    with patch.object(dashboard_app.go, "Figure", FakeFig):
+                        with patch.object(dashboard_app.dcc, "Graph", side_effect=mock_graph):
+                            result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
 
-        assert hasattr(result, "figure")
-        bar_trace = result.figure.data[0]
-        assert bar_trace.orientation == "h"
-        assert "sma_7_dist" in list(bar_trace.y)
-        assert "rsi_14" in list(bar_trace.y)
-        assert len(bar_trace.y) == 5
+        bar = captured_bars[0]
+        assert bar.orientation == "h"
+        assert "sma_7_dist" in list(bar.y)
+        assert "rsi_14" in list(bar.y)
+        assert len(bar.y) == 5
 
     def test_chart_limits_to_top_15(self):
         from dashboard import app as dashboard_app
@@ -207,15 +232,39 @@ class TestFeatureImportance:
         mock_booster.get_score.return_value = fake_importance
         mock_model = MagicMock()
         mock_model.get_booster.return_value = mock_booster
+        mock_model.load_model = MagicMock()
+
+        captured_bars = []
+
+        class FakeBar:
+            def __init__(self, **kwargs):
+                self.x = kwargs.get("x", [])
+                self.y = kwargs.get("y", [])
+                captured_bars.append(self)
+
+        class FakeFig:
+            def __init__(self, bar):
+                self.data = (bar,)
+                self.layout = MagicMock()
+            def update_layout(self, **kwargs):
+                pass
+
+        def mock_graph(**kwargs):
+            mock_obj = MagicMock()
+            mock_obj.figure = kwargs.get("figure")
+            return mock_obj
 
         with patch("os.path.exists", return_value=True):
             with patch("xgboost.XGBClassifier", return_value=mock_model):
-                result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
+                with patch.object(dashboard_app.go, "Bar", FakeBar):
+                    with patch.object(dashboard_app.go, "Figure", FakeFig):
+                        with patch.object(dashboard_app.dcc, "Graph", side_effect=mock_graph):
+                            result = dashboard_app.build_feature_importance_chart("crypto", "BTC", "1h")
 
-        bar_trace = result.figure.data[0]
-        assert len(bar_trace.y) == 15
-        assert "feature_0" in list(bar_trace.y)
-        assert "feature_19" not in list(bar_trace.y)
+        bar = captured_bars[0]
+        assert len(bar.y) == 15
+        assert "feature_0" in list(bar.y)
+        assert "feature_19" not in list(bar.y)
 
     def test_title_includes_asset_and_interval(self):
         from dashboard import app as dashboard_app
@@ -224,10 +273,33 @@ class TestFeatureImportance:
         mock_booster.get_score.return_value = {"rsi_14": 10.0}
         mock_model = MagicMock()
         mock_model.get_booster.return_value = mock_booster
+        mock_model.load_model = MagicMock()
+
+        captured_figs = []
+
+        class FakeBar:
+            def __init__(self, **kwargs):
+                self.x = kwargs.get("x", [])
+                self.y = kwargs.get("y", [])
+
+        class FakeFig:
+            def __init__(self, bar):
+                self.data = (bar,)
+                self.layout = MagicMock()
+            def update_layout(self, **kwargs):
+                captured_figs.append(kwargs.get("title", ""))
+
+        def mock_graph(**kwargs):
+            mock_obj = MagicMock()
+            mock_obj.figure = kwargs.get("figure")
+            return mock_obj
 
         with patch("os.path.exists", return_value=True):
             with patch("xgboost.XGBClassifier", return_value=mock_model):
-                result = dashboard_app.build_feature_importance_chart("stocks", "AAPL", "1d")
+                with patch.object(dashboard_app.go, "Bar", FakeBar):
+                    with patch.object(dashboard_app.go, "Figure", FakeFig):
+                        with patch.object(dashboard_app.dcc, "Graph", side_effect=mock_graph):
+                            result = dashboard_app.build_feature_importance_chart("stocks", "AAPL", "1d")
 
-        assert "AAPL" in result.figure.layout.title.text
-        assert "1d" in result.figure.layout.title.text
+        assert "AAPL" in captured_figs[0]
+        assert "1d" in captured_figs[0]


### PR DESCRIPTION
added a new "model insights" tab to the dashboard with an interactive feature importance chart. right now feature importance only existed as a static png in generate_figures.py for btc 1h only, so you couldnt show it live in the dashboard or switch between models.

what changed:
     - new "model insights" tab in the dashboard (next to model health)
     - asset class, asset, and interval dropdowns that chain together
     - loads any of the 45 xgboost models and extracts top 15 features by gain using booster.get_score(importance_type="gain")
     - shows a horizontal bar chart with feature names and gain values
     - handles missing models and missing importance data gracefully with warning alerts
     - removed the dead gold_crypto_predictions and gold_stock_predictions options from the data explorer dropdown that were
       always erroring

how it works:
     - pick asset class (crypto/stocks), then asset, then interval from the dropdowns
     - the callback loads the xgboost model json from src/models/{crypto,stocks}/
     - it calls get_booster().get_score(importance_type="gain") to get feature importance
     - if that returns empty, it falls back to model.feature_importances_ from the metadata
     - sorts by gain, takes top 15, and renders a plotly horizontal bar chart
     - the tab is named "model insights" so the accuracy bar chart (issue #181 ) and confusion matrix (issue #182) can go in the
       same tab later

files changed:
     - dashboard/app.py - new tab, render_model_insights(), 3 callbacks (asset dropdown, interval dropdown, chart builder),
       removed dead prediction table options from data explorer
     - tests/test_dashboard.py - 4 new tests in TestFeatureImportance class (missing model warning, top features shown, limited to
        15, title includes asset and interval)

tested:
     - all 15 dashboard tests pass (11 existing + 4 new)
   

- Close issue #180 